### PR TITLE
Ensure scan pool is shutdown on dialog unmount

### DIFF
--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -363,7 +363,14 @@ class SpectrApp(App):
             self._poll_thread.join()
 
         if self._poll_pool:
-            self._poll_pool.shutdown(wait=False, cancel_futures=True)
+            self._poll_pool.shutdown(wait=True, cancel_futures=True)
+            self._poll_pool = None
+
+        # If the ticker dialog is still open, ensure its scan pool shuts down
+        for screen in list(self.screen_stack):
+            if isinstance(screen, TickerInputDialog) and getattr(screen, "_scan_pool", None):
+                screen._scan_pool.shutdown(wait=False, cancel_futures=True)
+                screen._scan_pool = None
 
         if self._consumer_task:
             self._update_queue.put_nowait(None)

--- a/src/spectr/views/ticker_input_dialog.py
+++ b/src/spectr/views/ticker_input_dialog.py
@@ -115,6 +115,9 @@ class TickerInputDialog(ModalScreen):
         # cancel the refresher when the dialog closes
         self._refresh_job.stop()
         self._refresh_job = None
+        if self._scan_pool:
+            self._scan_pool.shutdown(wait=False, cancel_futures=True)
+            self._scan_pool = None
 
     def on_data_table_row_selected(
             self,


### PR DESCRIPTION
## Summary
- release scanning thread pool when `TickerInputDialog` is closed
- fully shut down polling executor and residual scan pools on app shutdown

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683fc6204224832e9c6176895ae150b7