### PR TITLE
Display relative volume and float shares

### DIFF
--- a/src/spectr/fetch/data_interface.py
+++ b/src/spectr/fetch/data_interface.py
@@ -27,3 +27,8 @@ class DataInterface(ABC):
     def has_recent_positive_news(self, symbol: str, hours: int = 12) -> bool:
          # True if FMP has any bullish news for *symbol* in the last *hours*.
         pass
+
+    @abstractmethod
+    def fetch_company_profile(self, symbol: str) -> dict:
+        """Return company profile information such as share float."""
+        pass

--- a/src/spectr/fetch/fmp.py
+++ b/src/spectr/fetch/fmp.py
@@ -134,3 +134,15 @@ class FMPInterface(DataInterface):
         except Exception as exc:
             log.debug(f"news lookup failed for {symbol}: {exc}")
             return False
+
+    def fetch_company_profile(self, symbol: str) -> dict:
+        """Fetch profile information such as share float."""
+        url = f"https://financialmodelingprep.com/api/v3/profile/{symbol}?apikey={FMP_API_KEY}"
+        try:
+            data = requests.get(url, timeout=10).json()
+            if isinstance(data, list) and data:
+                return data[0]
+            return {}
+        except Exception as exc:
+            log.debug(f"Failed to fetch profile for {symbol}: {exc}")
+            return {}

--- a/src/spectr/fetch/robinhood.py
+++ b/src/spectr/fetch/robinhood.py
@@ -116,6 +116,17 @@ class RobinhoodInterface(BrokerInterface, DataInterface):
                 return True
         return False
 
+    def fetch_company_profile(self, symbol: str) -> dict:
+        """Return basic company info. Robinhood does not expose float shares."""
+        try:
+            profile = r.stocks.get_fundamentals(symbol)
+            if isinstance(profile, list) and profile:
+                return profile[0]
+            return {}
+        except Exception as exc:
+            log.debug(f"profile lookup failed for {symbol}: {exc}")
+            return {}
+
     # ------------- BrokerInterface methods -------------
 
     def has_pending_order(self, symbol, real_trades=False):

--- a/src/spectr/utils.py
+++ b/src/spectr/utils.py
@@ -39,6 +39,18 @@ def load_cache(symbol):
         log.debug("Cache not found.")
     return pd.DataFrame() # Return empty dataframe.
 
+
+def human_format(num: float) -> str:
+    """Return a human friendly string for large integers."""
+    num = float(num)
+    for unit in ("", "K", "M", "B", "T"):
+        if abs(num) < 1000.0:
+            if unit:
+                return f"{num:.1f}{unit}"
+            return f"{num:.0f}"
+        num /= 1000.0
+    return f"{num:.1f}P"
+
 def inject_quote_into_df(
     df: pd.DataFrame,
     quote: dict,


### PR DESCRIPTION
## Summary
- add new `fetch_company_profile` API method
- implement profile retrieval for FMP and Robinhood
- compute and display average volume and float shares in top gainers and scanner tables
- show % average volume for scanner rows
- include a helper to format large numbers

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68428d3121b4832ebbd8837b54206060