### PR TITLE
Fix portfolio screen live trading toggle

### DIFF
--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -627,6 +627,8 @@ class SpectrApp(App):
                     BROKER_API.get_all_orders,
                     self.args.real_trades,
                     self.set_real_trades,
+                    BROKER_API.get_balance,
+                    BROKER_API.get_positions,
                 )
             )
 


### PR DESCRIPTION
## Summary
- refresh holdings and account info when trade mode toggles
- wire portfolio screen to fetch account data on demand

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842a0b3fc08832e97437437d4da75e2