### PR TITLE
Populate table with volume metrics

### DIFF
--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -534,6 +534,7 @@ class SpectrApp(App):
             TickerInputDialog(
                 callback=self.on_ticker_submit,
                 top_movers_cb=DATA_API.fetch_top_movers,
+                quote_cb=DATA_API.fetch_quote,
                 scanner_results=self.scanner_results,
             )
         )


### PR DESCRIPTION
## Summary
- fetch quote data when displaying top movers and scanner results
- show `% Avg Vol`, `Avg Vol`, and `Float` columns

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6842a3c62aa8832eaa0bbc94bd273348