### PR TITLE
Swap scanner and gainer tables

### DIFF
--- a/src/spectr/views/ticker_input_dialog.py
+++ b/src/spectr/views/ticker_input_dialog.py
@@ -46,15 +46,15 @@ class TickerInputDialog(ModalScreen):
                 Button("Submit", id="submit-button", variant="success"),
                 id="ticker_input_row",
             ),
+            Label("Scanner results:", id="scanner-title"),
+            Container(
+                DataTable(id="scanner-table"),
+                id="scanner-container",
+            ),
             Label("Top 20 gainers today:", id="gainers-title"),
             Container(
                 DataTable(id="gainers-table"),
                 id="gainers-container",
-            ),
-            Label("Scanner results:", id="scanner-title"),
-            Container(
-            DataTable(id="scanner-table"),
-                id="scanner-container",
             ),
             id="ticker_input_dlg_body",
         )


### PR DESCRIPTION
## Summary
- change ticker input dialog layout so scanner table appears above top gainers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843b6c0c98c832eb998efe9f7ff8d4d