### PR TITLE
Add auto-trading switch to Portfolio screen

### DIFF
--- a/src/spectr/default.tcss
+++ b/src/spectr/default.tcss
@@ -205,6 +205,10 @@ PortfolioScreen {
     padding: 0 1;
 }
 
+#auto-trade-switch {
+    padding: 0 1;
+}
+
 #orders-table, #holdings-table {
     width: 100%;
     height: 11;

--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -715,6 +715,8 @@ class SpectrApp(App):
                     BROKER_API.get_all_orders,
                     self.args.real_trades,
                     self.set_real_trades,
+                    self.auto_trading_enabled,
+                    self.set_auto_trading,
                     BROKER_API.get_balance,
                     BROKER_API.get_positions,
                 )
@@ -756,6 +758,11 @@ class SpectrApp(App):
         self.args.real_trades = enabled
         if hasattr(BROKER_API, "_real_trades"):
             setattr(BROKER_API, "_real_trades", enabled)
+
+    def set_auto_trading(self, enabled: bool) -> None:
+        """Enable or disable auto trading mode."""
+        self.auto_trading_enabled = enabled
+        self.update_status_bar()
 
     # ---------- Back-test workflow ----------
 


### PR DESCRIPTION
## Summary
- add auto-trading switch styling
- allow PortfolioScreen to toggle auto trading
- display the new switch next to paper/live switch
- handle auto-trade toggle in main app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68465b18782c832ea8fc3cb0646aa739