### PR TITLE
Fix exit hang

### DIFF
--- a/src/spectr/daemon_thread_pool.py
+++ b/src/spectr/daemon_thread_pool.py
@@ -1,0 +1,27 @@
+from concurrent.futures.thread import ThreadPoolExecutor, _worker, _threads_queues
+import threading
+import weakref
+
+
+class DaemonThreadPoolExecutor(ThreadPoolExecutor):
+    """ThreadPoolExecutor that spawns daemon worker threads."""
+
+    def _adjust_thread_count(self):
+        if self._idle_semaphore.acquire(timeout=0):
+            return
+
+        def weakref_cb(_, q=self._work_queue):
+            q.put(None)
+
+        num_threads = len(self._threads)
+        if num_threads < self._max_workers:
+            thread_name = "%s_%d" % (self._thread_name_prefix or self, num_threads)
+            t = threading.Thread(
+                name=thread_name,
+                target=_worker,
+                args=(weakref.ref(self, weakref_cb), self._work_queue, self._initializer, self._initargs),
+            )
+            t.daemon = True
+            t.start()
+            self._threads.add(t)
+            _threads_queues[t] = self._work_queue


### PR DESCRIPTION
## Summary
- ensure threads in the worker pools are daemonic
- shut pools down before joining threads and use timeouts
- move `DaemonThreadPoolExecutor` to its own module

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68467b6e5cd0832ebb1f5ab1f832bce3