### PR TITLE
Fix hang on exit

### DIFF
--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -16,7 +16,6 @@ from datetime import datetime, timedelta
 
 import backtrader as bt
 import pandas as pd
-import playsound
 from dotenv import load_dotenv
 from textual.app import App, ComposeResult
 from textual.reactive import reactive
@@ -27,7 +26,7 @@ import metrics
 import utils
 from CustomStrategy import CustomStrategy
 from fetch.broker_interface import BrokerInterface, OrderSide, OrderType
-from utils import load_cache, save_cache
+from utils import load_cache, save_cache, play_sound
 from views.backtest_input_dialog import BacktestInputDialog
 from views.backtest_result_screen import BacktestResultScreen
 from views.order_dialog import OrderDialog
@@ -292,11 +291,11 @@ class SpectrApp(App):
                 if signal == "buy":
                     log.debug("Buy signal detected!")
                     self.signal_detected.append((symbol, curr_price, signal))
-                    playsound.playsound(BUY_SOUND_PATH)
+                    play_sound(BUY_SOUND_PATH)
                 elif signal == "sell":
                     log.debug("Sell signal detected!")
                     self.signal_detected.append((symbol, curr_price, signal))
-                    playsound.playsound(SELL_SOUND_PATH)
+                    play_sound(SELL_SOUND_PATH)
 
             # Notify UI thread
             self.df_cache[symbol] = df
@@ -370,7 +369,7 @@ class SpectrApp(App):
                             msg = f"REAL {msg}"
                         self.signal_detected.remove(signal)
                         BROKER_API.submit_order(symbol, side, OrderType.MARKET, self.args.real_trades)
-                        playsound.playsound(BUY_SOUND_PATH if sig == "buy" else SELL_SOUND_PATH)
+                        play_sound(BUY_SOUND_PATH if sig == "buy" else SELL_SOUND_PATH)
             elif symbol == self.ticker_symbols[self.active_symbol_index]:
                 if not self.is_backtest:
                     df = self.df_cache.get(symbol)
@@ -481,7 +480,7 @@ class SpectrApp(App):
                 self._save_scanner_cache(results)
                 if results:
                     try:
-                        playsound.playsound(BUY_SOUND_PATH, block=False)
+                        play_sound(BUY_SOUND_PATH)
                     except Exception as exc:
                         log.debug(f"scan-sound failed: {exc}")
             except Exception as exc:

--- a/src/spectr/utils.py
+++ b/src/spectr/utils.py
@@ -7,6 +7,8 @@ from tzlocal import get_localzone
 
 import pandas as pd
 import pytz
+import threading
+import playsound
 
 
 LOG_FILE = 'signal_log.csv'
@@ -50,6 +52,16 @@ def human_format(num: float) -> str:
             return f"{num:.0f}"
         num /= 1000.0
     return f"{num:.1f}P"
+
+
+def play_sound(path: str) -> None:
+    """Play a sound in a daemon thread to avoid blocking app exit."""
+
+    threading.Thread(
+        target=playsound.playsound,
+        args=(path,),
+        daemon=True,
+    ).start()
 
 def inject_quote_into_df(
     df: pd.DataFrame,

--- a/src/spectr/views/ticker_input_dialog.py
+++ b/src/spectr/views/ticker_input_dialog.py
@@ -5,7 +5,7 @@ from textual import events
 from textual.widgets import Input, Label, Button, DataTable
 from textual.containers import Vertical, Horizontal, Container
 from textual.screen import ModalScreen
-import playsound
+from utils import play_sound
 import utils
 
 log = logging.getLogger(__name__)
@@ -257,7 +257,7 @@ class TickerInputDialog(ModalScreen):
                     utils.human_format(row.get("float", 0)),
                 )
             try:
-                playsound.playsound(SCAN_SOUND_PATH, block=False)
+                play_sound(SCAN_SOUND_PATH)
             except Exception as exc:
                 log.debug(f"scan-sound failed: {exc}")
 


### PR DESCRIPTION
## Summary
- play alert sounds via helper that uses a daemon thread
- update sound calls to avoid non-daemon threads

## Testing
- `python -m py_compile src/spectr/spectr.py src/spectr/views/ticker_input_dialog.py src/spectr/utils.py`

------
https://chatgpt.com/codex/tasks/task_e_684687cfc734832e8f829c50e52071b7