### PR TITLE
Fix equity curve not resetting between accounts

### DIFF
--- a/src/spectr/views/equity_curve_view.py
+++ b/src/spectr/views/equity_curve_view.py
@@ -15,6 +15,11 @@ class EquityCurveView(Static):
         super().__init__(*args, **kwargs)
         self.data: list[tuple[datetime, float, float]] = []
 
+    def reset(self) -> None:
+        """Clear all recorded data points and refresh the view."""
+        self.data.clear()
+        self.refresh()
+
     def add_point(self, cash: float, total: float) -> None:
         """Append a new data point and trigger a refresh."""
         self.data.append((datetime.now(), cash, total))

--- a/src/spectr/views/portfolio_screen.py
+++ b/src/spectr/views/portfolio_screen.py
@@ -284,6 +284,8 @@ class PortfolioScreen(Screen):
             self.real_trades = event.value
             if callable(self._set_real_trades_cb):
                 self._set_real_trades_cb(event.value)
+            # Switching accounts should start a fresh equity curve
+            self.equity_view.reset()
             await self._reload_account_data()
             await self._refresh_orders()
         elif event.switch.id == "auto-trade-switch":


### PR DESCRIPTION
## Summary
- add a `reset` helper to `EquityCurveView`
- clear equity curve points when switching between Live and Paper modes

## Testing
- `python -m compileall -q src/spectr/views/equity_curve_view.py src/spectr/views/portfolio_screen.py`

------
https://chatgpt.com/codex/tasks/task_e_6847d434aa58832eaf7bd89b92395089