### PR TITLE
Improve equity curve updates

### DIFF
--- a/src/spectr/views/equity_curve_view.py
+++ b/src/spectr/views/equity_curve_view.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import plotext as plt
 from rich.text import Text
@@ -15,6 +15,9 @@ class EquityCurveView(Static):
         super().__init__(*args, **kwargs)
         self.data: list[tuple[datetime, float, float]] = []
 
+        # Limit history to the last 4 hours
+        self.history_window = timedelta(hours=4)
+
     def reset(self) -> None:
         """Clear all recorded data points and refresh the view."""
         self.data.clear()
@@ -22,7 +25,10 @@ class EquityCurveView(Static):
 
     def add_point(self, cash: float, total: float) -> None:
         """Append a new data point and trigger a refresh."""
-        self.data.append((datetime.now(), cash, total))
+        now = datetime.now()
+        self.data.append((now, cash, total))
+        cutoff = now - self.history_window
+        self.data = [d for d in self.data if d[0] >= cutoff]
         if len(self.data) > 1000:
             self.data = self.data[-1000:]
         self.refresh()

--- a/src/spectr/views/portfolio_screen.py
+++ b/src/spectr/views/portfolio_screen.py
@@ -47,6 +47,7 @@ class PortfolioScreen(Screen):
         set_auto_trading_cb=None,
         balance_callback=None,
         positions_callback=None,
+        equity_data: Optional[list] = None,
     ) -> None:
         super().__init__()
         self.cash = cash or 0.0
@@ -91,6 +92,9 @@ class PortfolioScreen(Screen):
         self.positions_callback = positions_callback
         self._refresh_job = None  # handle for cancel
         self._balance_job = None  # periodic balance refresher
+
+        if equity_data:
+            self.equity_view.data = list(equity_data)
 
         # Initial placeholder content
         acct = "LIVE" if self.real_trades else "PAPER"


### PR DESCRIPTION
## Summary
- keep a four‑hour history of equity data in `EquityCurveView`
- store latest quotes and compute portfolio value every 30 seconds
- update equity curve and portfolio screen with computed totals
- pass equity history when opening the portfolio screen

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849263d863c832ebd153a150a3e5e6c