### PR TITLE
Add cancel order functionality

### DIFF
--- a/src/spectr/fetch/alpaca.py
+++ b/src/spectr/fetch/alpaca.py
@@ -279,3 +279,16 @@ class AlpacaInterface(BrokerInterface):
         except Exception as exc:
             log.error(f"ORDER FAILED: {exc}")
             raise
+
+    # ------------------------------------------------------------------ #
+    #  Cancel an existing open order.
+    # ------------------------------------------------------------------ #
+    def cancel_order(self, order_id: str) -> bool:
+        try:
+            api = self.get_api()
+            api.cancel_order_by_id(order_id)
+            log.debug(f"Order cancelled: {order_id}")
+            return True
+        except Exception as exc:
+            log.error(f"Failed to cancel order {order_id}: {exc}")
+            return False

--- a/src/spectr/fetch/broker_interface.py
+++ b/src/spectr/fetch/broker_interface.py
@@ -75,4 +75,9 @@ class BrokerInterface(ABC):
     def submit_order(self, symbol: str, side: OrderSide, type: OrderType, quantity: float = 1.0):
         """Submit a buy/sell order."""
         pass
+
+    @abstractmethod
+    def cancel_order(self, order_id: str) -> bool:
+        """Cancel an open order by its unique id. Returns True on success."""
+        pass
     

--- a/src/spectr/fetch/robinhood.py
+++ b/src/spectr/fetch/robinhood.py
@@ -150,3 +150,12 @@ class RobinhoodInterface(BrokerInterface, DataInterface):
             log.debug(f"ORDER PLACED: {side.name.upper()} {qty} shares of {symbol}")
         except Exception as e:
             log.error(f"ORDER FAILED: {e}")
+
+    def cancel_order(self, order_id: str) -> bool:
+        try:
+            r.orders.cancel_stock_order(order_id)
+            log.debug(f"Cancelled order {order_id}")
+            return True
+        except Exception as exc:
+            log.error(f"Failed to cancel order {order_id}: {exc}")
+            return False

--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -858,6 +858,7 @@ class SpectrApp(App):
                     positions,
                     orders,
                     BROKER_API.get_all_orders,
+                    BROKER_API.cancel_order,
                     self.args.real_trades,
                     self.set_real_trades,
                     self.auto_trading_enabled,


### PR DESCRIPTION
## Summary
- add `cancel_order` to broker interface
- implement cancel support for Alpaca and Robinhood brokers
- show a `Cancel` action on open orders in Portfolio screen
- handle cancel button presses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68499bd0d1fc832eb8efe72ffd91d261