### PR TITLE
Add strategy signals screen and custom strategy logging

### DIFF
--- a/src/spectr/views/strategy_screen.py
+++ b/src/spectr/views/strategy_screen.py
@@ -1,0 +1,33 @@
+from textual.screen import Screen
+from textual.widgets import DataTable, Header, Footer
+from textual.reactive import reactive
+
+class StrategyScreen(Screen):
+    """Modal screen listing live strategy signals."""
+    BINDINGS = [
+        ("s", "app.pop_screen", "Back"),
+        ("escape", "app.pop_screen", "Back"),
+    ]
+
+    signals: reactive[list] = reactive([])
+
+    def __init__(self, signals: list[dict]):
+        super().__init__()
+        self.signals = signals
+
+    def compose(self):
+        table = DataTable(zebra_stripes=True, header_style="bold")
+        table.add_columns("Date/Time", "Symbol", "Side", "Price", "Reason")
+        for sig in sorted(self.signals, key=lambda r: r["time"]):
+            dt = sig["time"].strftime("%Y-%m-%d %H:%M") if sig.get("time") else ""
+            price = sig.get("price")
+            table.add_row(
+                dt,
+                sig.get("symbol", ""),
+                sig.get("side", "").upper(),
+                f"{price:.2f}" if price is not None else "",
+                sig.get("reason", ""),
+            )
+        yield Header(show_clock=False)
+        yield table
+        yield Footer()


### PR DESCRIPTION
## Summary
- fix spectr import to use `custom_strategy.py`
- implement `CustomStrategy` with signal detection returning side, symbol and reason
- log detected signals and create new `StrategyScreen` to display them
- add `s` key binding for toggling Strategy screen
- update backtest strategy call

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849d3d4edfc832eb33bd6e9382755e0