### PR TITLE
Add Robinhood paper trading warning

### DIFF
--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -237,6 +237,10 @@ class SpectrApp(App):
         self._equity_thread.start()
 
         self.update_status_bar()
+        if self.args.broker == "robinhood" and self.args.real_trades:
+            self.query_one("#overlay-text", TopOverlay).flash_message(
+                "Robinhood does NOT support PAPER TRADING!", style="bold red"
+            )
         log.debug("starting consumer task")
         self._consumer_task = asyncio.create_task(self._process_updates())
 
@@ -852,6 +856,7 @@ class SpectrApp(App):
                     BROKER_API.cancel_order,
                     self.args.real_trades,
                     self.set_real_trades,
+                    self.args.broker == "robinhood" and self.args.real_trades,
                     self.auto_trading_enabled,
                     self.set_auto_trading,
                     BROKER_API.get_balance,

--- a/src/spectr/views/portfolio_screen.py
+++ b/src/spectr/views/portfolio_screen.py
@@ -44,6 +44,7 @@ class PortfolioScreen(Screen):
         cancel_order_callback,
         real_trades: bool,
         set_real_trades_cb=None,
+        disable_live_switch: bool = False,
         auto_trading: bool = False,
         set_auto_trading_cb=None,
         balance_callback=None,
@@ -59,6 +60,7 @@ class PortfolioScreen(Screen):
         if self.cached_orders:
             self.cached_orders.sort(key=self._order_date, reverse=True)
         self.real_trades = real_trades
+        self.disable_live_switch = disable_live_switch
         self._has_cached_balance = cash is not None
         self._has_cached_positions = positions is not None
         self._has_cached_orders = orders is not None
@@ -90,6 +92,7 @@ class PortfolioScreen(Screen):
         )
         self._cancel_col = self.order_table_columns[-1]
         self.mode_switch = Switch(value=self.real_trades, id="trade-mode-switch")
+        self.mode_switch.disabled = self.disable_live_switch
         self.auto_switch = Switch(value=self.auto_trading_enabled, id="auto-trade-switch")
         self.orders_callback = orders_callback
         self.balance_callback = balance_callback


### PR DESCRIPTION
## Summary
- warn that Robinhood doesn't support paper trading when using live trades
- disable live-trade switch if Robinhood is the broker

## Testing
- `python -m py_compile src/spectr/spectr.py src/spectr/views/portfolio_screen.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a71eb54bc832eab42d1e73c55e178