### PR TITLE
Add Trade Amount input and auto qty

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ BYOS - Bring Your Own Strategy. You must implement your own trading strategy in 
 - 🔄 Click symbols in Top Gainers list to add to watchlist.
 - 🔄 Scanner that filters top 50 gainers for favorable conditions.
 - 💵 See portfolio info + open / pending orders with `P`.
+- 💵 Specify a default Trade Amount from the portfolio screen to pre-fill buy orders.
 - 🧠 Supports MACD, Bollinger Bands, and Volume / VWAP.
 - 💵 Live trading based on your custom strategy.
 - 💵 Paper trading based on your custom strategy. (Alpaca-only)

--- a/src/spectr/default.tcss
+++ b/src/spectr/default.tcss
@@ -209,6 +209,16 @@ PortfolioScreen {
     padding: 1 1;
 }
 
+#trade-amount-row {
+    width: 50%;
+    height: 3;
+    content-align-horizontal: center;
+}
+
+#trade-amount-input {
+    width: 20%;
+}
+
 #orders-table, #holdings-table {
     width: 100%;
     height: 11;

--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -115,6 +115,7 @@ class SpectrApp(App):
     active_symbol_index = reactive(0)
     auto_trading_enabled: reactive[bool] = reactive(False)
     is_backtest: reactive[bool] = reactive(False)
+    trade_amount: reactive[float] = reactive(0.0)
 
     symbol_view: reactive[SymbolView] = reactive(None)
 
@@ -167,6 +168,8 @@ class SpectrApp(App):
         self.signal_detected = []
         self.strategy_signals: list[dict] = []
         self._shutting_down = False
+
+        self.trade_amount = 0.0
 
         self._scanner_cache_file = pathlib.Path.home() / ".spectr_scanner_cache.json"
         self.scanner_results: list[dict] = self._load_scanner_cache()
@@ -660,6 +663,7 @@ class SpectrApp(App):
                 pos_pct=pos_pct,
                 get_pos_cb=BROKER_API.get_position,
                 get_price_cb=DATA_API.fetch_quote,
+                trade_amount=self.trade_amount if side == OrderSide.BUY else 0.0,
             )
         )
 
@@ -803,6 +807,8 @@ class SpectrApp(App):
                     BROKER_API.get_balance,
                     BROKER_API.get_positions,
                     equity_data=self._equity_curve_data,
+                    trade_amount=self.trade_amount,
+                    set_trade_amount_cb=self.set_trade_amount,
                 )
             )
 
@@ -847,6 +853,13 @@ class SpectrApp(App):
         """Enable or disable auto trading mode."""
         self.auto_trading_enabled = enabled
         self.update_status_bar()
+
+    def set_trade_amount(self, amount: float) -> None:
+        """Persist the trade amount value used for BUY orders."""
+        try:
+            self.trade_amount = float(amount)
+        except ValueError:
+            self.trade_amount = 0.0
 
     # ---------- Back-test workflow ----------
 

--- a/src/spectr/views/order_dialog.py
+++ b/src/spectr/views/order_dialog.py
@@ -72,6 +72,7 @@ class OrderDialog(ModalScreen):
         pos_pct: float = 100.0,
         get_pos_cb: Callable,
         get_price_cb: Callable,
+        trade_amount: float = 0.0,
     ) -> None:
         super().__init__()
         self.side         = side
@@ -79,6 +80,7 @@ class OrderDialog(ModalScreen):
         self.pos_pct      = pos_pct
         self._get_pos      = get_pos_cb
         self._get_price   = get_price_cb
+        self.trade_amount = trade_amount
         self._refresh_job = None
 
         self.pos_qty   = None
@@ -204,6 +206,9 @@ class OrderDialog(ModalScreen):
             new_price = new_price.get("price", 0)
             self.price = new_price
             self.query_one("#dlg_price", Static).update(self._price_fmt())
+            if self.side == OrderSide.BUY and self.trade_amount > 0 and self.price > 0:
+                self.qty = self.trade_amount / self.price
+                self.query_one("#dlg_qty_in", Input).value = str(self.qty)
             self._update_total()
 
     async def on_select_changed(self, event: Select.Changed):


### PR DESCRIPTION
## Summary
- add a field on the portfolio screen for setting a default trade amount
- update order dialog to compute buy quantity based on Trade Amount
- plumb trade amount through SpectrApp
- document new feature in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f9dcdc83c832e9f23a467c010097b