### PR TITLE
Fix strategy screen table build

### DIFF
--- a/src/spectr/views/strategy_screen.py
+++ b/src/spectr/views/strategy_screen.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from textual.screen import Screen
 from textual.widgets import DataTable, Header, Footer
 from textual.reactive import reactive
@@ -18,8 +20,9 @@ class StrategyScreen(Screen):
     def compose(self):
         table = DataTable(zebra_stripes=True)
         table.add_columns("Date/Time", "Symbol", "Side", "Price", "Reason")
-        for sig in sorted(self.signals, key=lambda r: r["time"]):
-            dt = sig["time"].strftime("%Y-%m-%d %H:%M") if sig.get("time") else ""
+        for sig in sorted(self.signals, key=lambda r: r.get("time") or datetime.min):
+            dt_raw = sig.get("time")
+            dt = dt_raw.strftime("%Y-%m-%d %H:%M") if dt_raw else ""
             price = sig.get("price")
             table.add_row(
                 dt,


### PR DESCRIPTION
## Summary
- ensure signals with no time don't break `strategy_screen`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850bd58f6b0832e88d043df56995781