### PR TITLE
Improve strategy screen appearance

### DIFF
--- a/src/spectr/default.tcss
+++ b/src/spectr/default.tcss
@@ -259,3 +259,17 @@ BacktestResultScreen {
     height: 30;
     background: black;
 }
+
+StrategyScreen {
+    align: center middle;
+}
+
+#strategy-screen {
+    width: 75%;
+    height: 42;
+    background: #1a1a1a;
+    border: solid green;
+    padding: 1 2;
+    content-align-horizontal: center;
+    content-align-vertical: top;
+}

--- a/src/spectr/views/strategy_screen.py
+++ b/src/spectr/views/strategy_screen.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from textual.screen import Screen
 from textual.widgets import DataTable, Header, Footer
+from textual.containers import Vertical
 from textual.reactive import reactive
 
 class StrategyScreen(Screen):
@@ -31,6 +32,10 @@ class StrategyScreen(Screen):
                 f"{price:.2f}" if price is not None else "",
                 sig.get("reason", ""),
             )
-        yield Header(show_clock=False)
-        yield table
-        yield Footer()
+
+        yield Vertical(
+            Header(show_clock=False),
+            table,
+            Footer(),
+            id="strategy-screen",
+        )


### PR DESCRIPTION
## Summary
- update StrategyScreen layout to use a dialog container
- style StrategyScreen with the same dark theme as the other screens

## Testing
- `python -m compileall -q src/spectr/views/strategy_screen.py src/spectr/default.tcss`

------
https://chatgpt.com/codex/tasks/task_e_6850f3c4893c832e8dcdb3135db924ed