### PR TITLE
Fix non-blocking splash screen

### DIFF
--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -188,7 +188,8 @@ class SpectrApp(App):
         yield SymbolView(id="symbol-view")
 
     async def on_mount(self):
-        await self.push_screen(SplashScreen())
+        # Show splash screen without waiting for it to close
+        self.push_screen(SplashScreen())
         # Set symbols and active symbol
         self.ticker_symbols = self.args.symbols
         # Ensure any open positions are at the start of the watchlist.


### PR DESCRIPTION
## Summary
- push SplashScreen without awaiting it so on_mount continues

## Testing
- `python -m py_compile src/spectr/spectr.py`

------
https://chatgpt.com/codex/tasks/task_e_685238898274832e88b111a8aa1d4454