### PR TITLE
Display strategy reason in order dialog

### DIFF
--- a/src/spectr/default.tcss
+++ b/src/spectr/default.tcss
@@ -145,7 +145,7 @@ OrderDialog {
     background: #1a1a1a;
 }
 
-#dlg_title, #dlg_pos {
+#dlg_title, #dlg_pos, #dlg_reason {
     text-align: center;
     padding: 1 1;
 }

--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -252,7 +252,7 @@ class SpectrApp(App):
                 df.at[df.index[-1], 'trade'] = signal  # mark bar for plotting
                 if signal == "buy":
                     log.debug("Buy signal detected!")
-                    self.signal_detected.append((symbol, curr_price, signal))
+                    self.signal_detected.append((symbol, curr_price, signal, reason))
                     self.strategy_signals.append({
                         "time": datetime.now(),
                         "symbol": symbol,
@@ -263,7 +263,7 @@ class SpectrApp(App):
                     play_sound(BUY_SOUND_PATH)
                 elif signal == "sell":
                     log.debug("Sell signal detected!")
-                    self.signal_detected.append((symbol, curr_price, signal))
+                    self.signal_detected.append((symbol, curr_price, signal, reason))
                     self.strategy_signals.append({
                         "time": datetime.now(),
                         "symbol": symbol,
@@ -318,7 +318,7 @@ class SpectrApp(App):
             # If a buy signal was triggered, switch to that symbol
             if len(self.signal_detected) > 0:
                 for signal in self.signal_detected:
-                    sym, price, sig = signal
+                    sym, price, sig, reason = signal
                     index = self.ticker_symbols.index(sym)
                     self.active_symbol_index = index
                     msg = f"{sym} @ {price} 🚀"
@@ -332,7 +332,7 @@ class SpectrApp(App):
                     if not self.auto_trading_enabled and sig:
                         self.signal_detected.remove(signal)
                         if (self.screen_stack and not isinstance(self.screen_stack[-1], OrderDialog)):
-                            self.open_order_dialog(side=side, pos_pct=100.0, symbol=sym)
+                            self.open_order_dialog(side=side, pos_pct=100.0, symbol=sym, reason=reason)
                         continue
                     else:
                         msg = f"ORDER SUBMITTED! {msg}"
@@ -655,7 +655,7 @@ class SpectrApp(App):
         symbol = self.ticker_symbols[self.active_symbol_index]
         self.open_order_dialog(OrderSide.SELL, 25.0, symbol)
 
-    def open_order_dialog(self, side: OrderSide, pos_pct: float, symbol: str):
+    def open_order_dialog(self, side: OrderSide, pos_pct: float, symbol: str, reason: str | None = None):
         if self._is_splash_active():
             return
         self.push_screen(
@@ -666,6 +666,7 @@ class SpectrApp(App):
                 get_pos_cb=BROKER_API.get_position,
                 get_price_cb=DATA_API.fetch_quote,
                 trade_amount=self.trade_amount if side == OrderSide.BUY else 0.0,
+                reason=reason,
             )
         )
 

--- a/src/spectr/views/order_dialog.py
+++ b/src/spectr/views/order_dialog.py
@@ -73,6 +73,7 @@ class OrderDialog(ModalScreen):
         get_pos_cb: Callable,
         get_price_cb: Callable,
         trade_amount: float = 0.0,
+        reason: str | None = None,
     ) -> None:
         super().__init__()
         self.side         = side
@@ -81,6 +82,7 @@ class OrderDialog(ModalScreen):
         self._get_pos      = get_pos_cb
         self._get_price   = get_price_cb
         self.trade_amount = trade_amount
+        self.reason       = reason
         self._refresh_job = None
 
         self.pos_qty   = None
@@ -88,11 +90,15 @@ class OrderDialog(ModalScreen):
 
     # ------------------------------------------------------------------
     def compose(self):
-        yield Vertical(
-            Static(f"[b]{self.side.name.upper()} {self.symbol}[/b]", id="dlg_title"),
+        components = [
+            Static(f"[b]{self.side.name.upper()} {self.symbol}[/b]", id="dlg_title")
+        ]
+        if self.reason:
+            components.append(Static(self.reason, id="dlg_reason"))
+        components += [
             Static(),
-            Static(self._price_fmt(),  id="dlg_price"),
-            Static(self._pos_fmt(),    id="dlg_pos"),
+            Static(self._price_fmt(), id="dlg_price"),
+            Static(self._pos_fmt(), id="dlg_pos"),
             Static(),
             Horizontal(
                 Label("Type:", id="dlg_ot_lbl"),
@@ -120,8 +126,9 @@ class OrderDialog(ModalScreen):
                 Button("Cancel", id="dlg_cancel", variant="error"),
                 id="dlg_buttons_row",
             ),
-            id="dlg_body",
-        )
+        ]
+
+        yield Vertical(*components, id="dlg_body")
 
     # ---------------- private helpers ---------------------------------
     def _price_fmt(self) -> str:


### PR DESCRIPTION
## Summary
- show strategy signal reason in the order dialog when opened from a signal
- forward reason through `open_order_dialog`
- display reason text in the dialog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68526371fbf8832e87c85af238265c8c