### PR TITLE
Adjust portfolio screen layout

### DIFF
--- a/src/spectr/default.tcss
+++ b/src/spectr/default.tcss
@@ -197,7 +197,7 @@ PortfolioScreen {
     height: 5
 }
 
-#mode-switch-container, #trade-switch-container {
+#mode-switch-container, #trade-switch-container, #trade-amount-container {
     width: 25%;
     height: 5;
 }
@@ -207,11 +207,6 @@ PortfolioScreen {
     height: 5;
     text-align: center;
     padding: 1 1;
-}
-
-#trade-amount-row {
-    width: 100%;
-    height: 1;
 }
 
 #trade-amount-input {

--- a/src/spectr/views/portfolio_screen.py
+++ b/src/spectr/views/portfolio_screen.py
@@ -197,13 +197,12 @@ class PortfolioScreen(Screen):
                     Static("Auto Trades"),
                     self.auto_switch,
                     id="trade-switch-container"),
+                Container(
+                    Static("Trade Amount $"),
+                    Input(id="trade-amount-input", placeholder="0.00"),
+                    id="trade-amount-container"),
                 id="trade-mode-container",
             ),
-            Horizontal(
-                Static("Trade Amount $"),
-                id="trade-amount-row",
-            ),
-            Input(id="trade-amount-input", placeholder="0.00"),
 
             self.equity_view,
 
@@ -372,6 +371,10 @@ class PortfolioScreen(Screen):
                 self.trade_amount = 0.0
             if callable(self._set_trade_amount_cb):
                 self._set_trade_amount_cb(self.trade_amount)
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        if event.input.id == "trade-amount-input":
+            event.input.blur()
 
     def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
         """Open an order dialog to sell when a holdings row is clicked."""


### PR DESCRIPTION
## Summary
- place the trade amount input on the same row as the toggle switches
- blur the trade amount input when submitted
- update stylesheet for new container

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68526b1e2470832e9980ccea23701ab9