### PR TITLE
Fix splash screen visibility

### DIFF
--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -119,7 +119,7 @@ class SpectrApp(App):
 
     def _is_splash_active(self) -> bool:
         """Return ``True`` if the splash screen is currently visible."""
-        return bool(self.screen_stack and isinstance(self.screen_stack[-1], SplashScreen))
+        return self.query_one("#splash", SplashScreen, expect_none=True) is not None
 
     def _prepend_open_positions(self) -> None:
         """Ensure open position symbols are at the start of ``ticker_symbols``."""
@@ -186,10 +186,9 @@ class SpectrApp(App):
     def compose(self) -> ComposeResult:
         yield TopOverlay(id="overlay-text")
         yield SymbolView(id="symbol-view")
+        yield SplashScreen()
 
     async def on_mount(self):
-        # Show splash screen without waiting for it to close
-        await self.push_screen(SplashScreen())
         # Set symbols and active symbol
         self.ticker_symbols = self.args.symbols
         # Ensure any open positions are at the start of the watchlist.
@@ -276,9 +275,8 @@ class SpectrApp(App):
             self.df_cache[symbol] = df
             self._update_queue.put(symbol)
             if symbol == self.ticker_symbols[self.active_symbol_index]:
-                if self.screen_stack and isinstance(self.screen_stack[-1], SplashScreen):
-                    # schedule screen pop on the main thread – we are in an executor
-                    self.call_from_thread(self.pop_screen)
+                if self._is_splash_active():
+                    self.call_from_thread(self.remove_splash)
                 # refresh the active view from the UI thread
                 self.call_from_thread(self.update_view, self.ticker_symbols[self.active_symbol_index])
 
@@ -826,7 +824,12 @@ class SpectrApp(App):
 
         self.update_status_bar()
         if self.query("#splash") and df is not None and not df.empty:
-            self.remove(self.query_one("#splash"))
+            self.remove_splash()
+
+    def remove_splash(self) -> None:
+        splash = self.query_one("#splash", SplashScreen, expect_none=True)
+        if splash:
+            self.remove(splash)
 
     def update_status_bar(self):
         live_icon = "🤖" if self.auto_trading_enabled else "🚫"

--- a/src/spectr/views/splash_screen.py
+++ b/src/spectr/views/splash_screen.py
@@ -1,4 +1,5 @@
-from textual.screen import Screen
+from textual.widget import Widget
+from textual.app import ComposeResult
 from textual.widgets import Static
 
 GHOST = """
@@ -44,8 +45,11 @@ GHOST = """
 """
 
 
-class SplashScreen(Screen):
+class SplashScreen(Widget):
     """Center-screen logo while data initialises."""
 
-    def compose(self):
+    def __init__(self) -> None:
+        super().__init__(id="splash")
+
+    def compose(self) -> ComposeResult:
         yield Static(GHOST, id="logo-art", classes="center")


### PR DESCRIPTION
## Summary
- add `SplashScreen` to the compose tree instead of pushing a screen
- convert `SplashScreen` to a widget and remove it once data loads

## Testing
- `python -m py_compile src/spectr/spectr.py src/spectr/views/splash_screen.py`


------
https://chatgpt.com/codex/tasks/task_e_6852d781b658832e835a107009a42551