### PR TITLE
Implement limit order defaults after hours

### DIFF
--- a/src/spectr/fetch/broker_interface.py
+++ b/src/spectr/fetch/broker_interface.py
@@ -72,7 +72,16 @@ class BrokerInterface(ABC):
         pass
 
     @abstractmethod
-    def submit_order(self, symbol: str, side: OrderSide, type: OrderType, quantity: float = 1.0):
+    def submit_order(
+        self,
+        symbol: str,
+        side: OrderSide,
+        type: OrderType,
+        quantity: float | None = None,
+        limit_price: float | None = None,
+        market_price: float | None = None,
+        real_trades: bool = False,
+    ):
         """Submit a buy/sell order."""
         pass
 

--- a/src/spectr/fetch/robinhood.py
+++ b/src/spectr/fetch/robinhood.py
@@ -215,16 +215,28 @@ class RobinhoodInterface(BrokerInterface, DataInterface):
             log.debug(f"Failed to fetch positions: {exc}")
             return []
 
-    def submit_order(self, symbol: str, side: OrderSide, type: OrderType, quantity: float = 1.0):
+    def submit_order(
+        self,
+        symbol: str,
+        side: OrderSide,
+        type: OrderType,
+        quantity: float | None = None,
+        limit_price: float | None = None,
+        market_price: float | None = None,
+        real_trades: bool = False,
+    ):
         try:
             if type != OrderType.MARKET:
                 log.error("RobinhoodInterface only supports market orders")
                 return
             if side == OrderSide.BUY:
-                r.orders.order_buy_market(symbol, quantity)
+                r.orders.order_buy_market(symbol, quantity or 1)
             else:
-                r.orders.order_sell_market(symbol, quantity)
-            log.debug(f"ORDER PLACED: {side.name.upper()} {quantity} shares of {symbol}")
+                r.orders.order_sell_market(symbol, quantity or 1)
+            price_disp = market_price if market_price is not None else "MKT"
+            log.debug(
+                f"ORDER PLACED: {side.name.upper()} {quantity or 1} shares of {symbol} @ {price_disp}"
+            )
         except Exception as exc:
             log.error(f"ORDER FAILED: {exc}")
 

--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -22,7 +22,7 @@ import utils
 #from custom_strategy import CustomStrategy
 from CustomStrategy import CustomStrategy
 from fetch.broker_interface import BrokerInterface, OrderSide, OrderType
-from utils import play_sound, get_historical_data, get_live_data
+from utils import play_sound, get_historical_data, get_live_data, is_market_open_now
 from views.backtest_input_dialog import BacktestInputDialog
 from views.backtest_result_screen import BacktestResultScreen
 from views.order_dialog import OrderDialog
@@ -338,7 +338,34 @@ class SpectrApp(App):
                         else:
                             msg = f"REAL {msg}"
                         self.signal_detected.remove(signal)
-                        BROKER_API.submit_order(symbol, side, OrderType.MARKET, self.args.real_trades)
+                        order_type = OrderType.MARKET
+                        limit_price = None
+                        if not is_market_open_now():
+                            quote = DATA_API.fetch_quote(symbol)
+                            order_type = OrderType.LIMIT
+                            if side == OrderSide.BUY:
+                                limit_price = (
+                                    quote.get("ask")
+                                    or quote.get("ask_price")
+                                    or quote.get("askPrice")
+                                    or quote.get("price")
+                                )
+                            else:
+                                limit_price = (
+                                    quote.get("bid")
+                                    or quote.get("bid_price")
+                                    or quote.get("bidPrice")
+                                    or quote.get("price")
+                                )
+                        BROKER_API.submit_order(
+                            symbol=symbol,
+                            side=side,
+                            type=order_type,
+                            quantity=1,
+                            limit_price=limit_price,
+                            market_price=price,
+                            real_trades=self.auto_trading_enabled,
+                        )
                         play_sound(BUY_SOUND_PATH if sig == "buy" else SELL_SOUND_PATH)
             elif symbol == self.ticker_symbols[self.active_symbol_index]:
                 if not self.is_backtest:
@@ -650,6 +677,25 @@ class SpectrApp(App):
     def open_order_dialog(self, side: OrderSide, pos_pct: float, symbol: str, reason: str | None = None):
         if self._is_splash_active():
             return
+        order_type = OrderType.MARKET
+        limit_price = None
+        if not is_market_open_now():
+            quote = DATA_API.fetch_quote(symbol)
+            order_type = OrderType.LIMIT
+            if side == OrderSide.BUY:
+                limit_price = (
+                    quote.get("ask")
+                    or quote.get("ask_price")
+                    or quote.get("askPrice")
+                    or quote.get("price")
+                )
+            else:
+                limit_price = (
+                    quote.get("bid")
+                    or quote.get("bid_price")
+                    or quote.get("bidPrice")
+                    or quote.get("price")
+                )
         self.push_screen(
             OrderDialog(
                 side=side,
@@ -659,6 +705,8 @@ class SpectrApp(App):
                 get_price_cb=DATA_API.fetch_quote,
                 trade_amount=self.trade_amount if side == OrderSide.BUY else 0.0,
                 reason=reason,
+                default_order_type=order_type,
+                default_limit_price=limit_price,
             )
         )
 
@@ -738,6 +786,9 @@ class SpectrApp(App):
                 side=msg.side,
                 type=msg.order_type,
                 quantity=msg.qty,
+                limit_price=msg.limit_price,
+                market_price=msg.price,
+                real_trades=self.auto_trading_enabled,
             )
         except Exception as e:
             log.error(e)

--- a/src/spectr/views/order_dialog.py
+++ b/src/spectr/views/order_dialog.py
@@ -74,6 +74,8 @@ class OrderDialog(ModalScreen):
         get_price_cb: Callable,
         trade_amount: float = 0.0,
         reason: str | None = None,
+        default_order_type: OrderType = OrderType.MARKET,
+        default_limit_price: float | None = None,
     ) -> None:
         super().__init__()
         self.side         = side
@@ -84,6 +86,9 @@ class OrderDialog(ModalScreen):
         self.trade_amount = trade_amount
         self.reason       = reason
         self._refresh_job = None
+
+        self.order_type  = default_order_type.name
+        self.limit_price = default_limit_price or 0.0
 
         self.pos_qty   = None
         self.pos_value = None
@@ -166,8 +171,11 @@ class OrderDialog(ModalScreen):
         qty_in = self.query_one("#dlg_qty_in", Input)
         qty_in.focus()
 
-        # hide limit row initially
-        self.query_one("#lim_row").display = False
+        # show or hide limit price row based on default order type
+        limit_row = self.query_one("#lim_row")
+        limit_row.display = self.order_type != OrderType.MARKET.name
+        if self.order_type != OrderType.MARKET.name and self.limit_price:
+            self.query_one("#dlg_lim_in", Input).value = str(self.limit_price)
 
         # Start disabled until position updates with a position to sell.
         # TODO: Add check for funds and disable BUY button if insufficient funds.


### PR DESCRIPTION
## Summary
- tweak broker interface to support optional market price logging
- show the price used when submitting orders in broker implementations
- adjust auto-trading to pass current quote and use auto-trading flag for real trades
- ensure order dialog submissions use auto-trading flag and pass quote price
- refine market-hours detection using US/Eastern timezone

## Testing
- `python -m compileall -q src`
- `python -m pip install -e .` *(fails: subprocess-exited-with-error)*


------
https://chatgpt.com/codex/tasks/task_e_68537013d108832e80f38f5c5678c3c7