### PR TITLE
Skip after-hours limit orders for crypto pairs

### DIFF
--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -22,7 +22,13 @@ import utils
 from custom_strategy import CustomStrategy
 #from CustomStrategy import CustomStrategy
 from fetch.broker_interface import BrokerInterface, OrderSide, OrderType
-from utils import play_sound, get_historical_data, get_live_data, is_market_open_now
+from utils import (
+    play_sound,
+    get_historical_data,
+    get_live_data,
+    is_market_open_now,
+    is_crypto_symbol,
+)
 from views.backtest_input_dialog import BacktestInputDialog
 from views.backtest_result_screen import BacktestResultScreen
 from views.order_dialog import OrderDialog
@@ -343,7 +349,7 @@ class SpectrApp(App):
                         BROKER_API.submit_order(symbol, side, OrderType.MARKET, 100.0, self.auto_trading_enabled)
                         order_type = OrderType.MARKET
                         limit_price = None
-                        if not is_market_open_now():
+                        if not is_market_open_now() and not is_crypto_symbol(symbol):
                             quote = DATA_API.fetch_quote(symbol)
                             order_type = OrderType.LIMIT
                             if side == OrderSide.BUY:
@@ -682,7 +688,7 @@ class SpectrApp(App):
             return
         order_type = OrderType.MARKET
         limit_price = None
-        if not is_market_open_now():
+        if not is_market_open_now() and not is_crypto_symbol(symbol):
             quote = DATA_API.fetch_quote(symbol)
             order_type = OrderType.LIMIT
             if side == OrderSide.BUY:

--- a/src/spectr/utils.py
+++ b/src/spectr/utils.py
@@ -106,6 +106,15 @@ def is_market_open_now(tz: ZoneInfo | None = None) -> bool:
     market_close = datetime.combine(now.date(), dtime(hour=16, minute=0), tzinfo=tz)
     return market_open <= now <= market_close
 
+
+CRYPTO_SUFFIXES = ("USD", "USDT", "USDC")
+
+
+def is_crypto_symbol(symbol: str) -> bool:
+    """Return True if *symbol* looks like a cryptocurrency pair."""
+    sym = symbol.upper()
+    return any(sym.endswith(sfx) and len(sym) > len(sfx) for sfx in CRYPTO_SUFFIXES)
+
 def inject_quote_into_df(
     df: pd.DataFrame,
     quote: dict,


### PR DESCRIPTION
## Summary
- add `is_crypto_symbol` helper in `utils`
- import and use helper in order logic
- avoid converting crypto orders to limit after hours

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68539887b634832e9235e94eacd4c71e