### PR TITLE
Add quit confirmation overlay

### DIFF
--- a/src/spectr/views/top_overlay.py
+++ b/src/spectr/views/top_overlay.py
@@ -28,6 +28,20 @@ class TopOverlay(Static):
             self._timer.stop()
         self._timer = self.set_timer(duration, self._clear_flash)
 
+    def show_prompt(self, msg: str, style: str = "bold yellow"):
+        """Display *msg* without auto clearing."""
+        if self._timer:
+            self._timer.stop()
+            self._timer = None
+        self.alert_text = f"[{style}]{msg}[/{style}]"
+
+    def clear_prompt(self) -> None:
+        """Remove any prompt text immediately."""
+        if self._timer:
+            self._timer.stop()
+            self._timer = None
+        self.alert_text = ""
+
     def _clear_flash(self):
         self.alert_text = ""
 


### PR DESCRIPTION
## Summary
- require confirmation before quitting the app
- add prompt display helpers to TopOverlay

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853ade5ca8c832ebb91b5ae954c9d57