### PR TITLE
Persist symbols between runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ BYOS - Bring Your Own Strategy. You must implement your own trading strategy in 
 -  ⌨ Cycle through unlimited # of symbols with 0-9 keys or + / - keys.
 - 🤖 Arm / dis-arm auto-trading with `Ctrl+A`
 - 🔄 Change symbols list with `~` or `T`
+- 💾 Symbols list automatically saved between sessions
 - 📌 Any stocks you currently own are automatically prepended to the watchlist
 - 🔄 Click symbols in Top Gainers list to add to watchlist.
 - 🔄 Scanner that filters top 50 gainers for favorable conditions.
@@ -84,7 +85,7 @@ python -m spectr --broker alpaca --data_api fmp --scale 0.5 --symbols NVDA,TSLA,
 
 | Flag                | Description                                             |
 |---------------------|---------------------------------------------------------|
-| `--symbols`         | List of stock tickers to track (e.g., NVDA,AAPL,BTCUSD) |
+| `--symbols`         | List of stock tickers to track (e.g., NVDA,AAPL,BTCUSD). If omitted, last used list is loaded from cache. |
 | `--broker`          | `alpaca` or `robinhood`                                 |
 | `--data_api`        | `alpaca`, `fmp`, or `robinhood`                         |
 | `--real_trades`     | If set, will place real trades.                         |

--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -9,6 +9,7 @@ import time
 import queue
 import threading
 import traceback
+import sys
 from datetime import datetime, timedelta
 
 import backtrader as bt
@@ -57,6 +58,9 @@ from views.strategy_screen import StrategyScreen
 # --- SOUND PATHS ---
 BUY_SOUND_PATH = 'res/buy.mp3'
 SELL_SOUND_PATH = 'res/sell.mp3'
+
+# File used to cache the last used ticker symbol list
+SYMBOLS_CACHE_PATH = pathlib.Path.home() / ".spectr_symbols_cache.json"
 
 REFRESH_INTERVAL = 60  # seconds
 SCANNER_INTERVAL = REFRESH_INTERVAL
@@ -192,6 +196,7 @@ class SpectrApp(App):
         self.scanner_results: list[dict] = self._load_scanner_cache()
         self._gainers_cache_file = pathlib.Path.home() / ".spectr_gainers_cache.json"
         self.top_gainers: list[dict] = self._load_gainers_cache()
+        self._symbols_cache_file = SYMBOLS_CACHE_PATH
 
         # Track latest quotes and equity curve
         self._latest_quotes: dict[str, float] = {}
@@ -426,6 +431,18 @@ class SpectrApp(App):
         except Exception:
             return []
 
+    def _save_symbols_cache(self) -> None:
+        try:
+            self._symbols_cache_file.write_text(json.dumps(self.ticker_symbols))
+        except Exception as exc:
+            log.error(f"symbols cache write failed: {exc}")
+
+    def _load_symbols_cache(self) -> list[str]:
+        try:
+            return json.loads(self._symbols_cache_file.read_text())
+        except Exception:
+            return []
+
     def _check_scan_symbol(self, row):
         """Fetch extra metrics for *row* and flag if it passes the filter."""
         sym = row["symbol"]
@@ -614,6 +631,8 @@ class SpectrApp(App):
             self._consumer_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 self._consumer_task = None
+
+        self._save_symbols_cache()
 
         log.debug("on_shutdown complete")
         self.exit()
@@ -1113,6 +1132,14 @@ if __name__ == "__main__":
                         )
     parser.add_argument('--debug', action='store_true')
     args = parser.parse_args()
+
+    if "--symbols" not in sys.argv:
+        try:
+            cached = json.loads(SYMBOLS_CACHE_PATH.read_text())
+            if isinstance(cached, list) and cached:
+                args.symbols = ",".join(cached)
+        except Exception:
+            pass
 
     args.symbols = [s.strip().upper() for s in args.symbols.split(",")]
     args.symbol = args.symbols[0]  # set initial active symbol


### PR DESCRIPTION
## Summary
- add persistent symbol cache and load on startup
- document auto-saving of symbol list

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68544fd66400832eb1771260a6c42f10