### PR TITLE
Check pending orders before auto trading

### DIFF
--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -360,6 +360,12 @@ class SpectrApp(App):
                             self.open_order_dialog(side=side, pos_pct=100.0, symbol=sym, reason=reason)
                         continue
                     else:
+                        # Skip auto-ordering if there's already an open order
+                        if BROKER_API.has_pending_order(sym):
+                            log.info(f"Pending order for {sym}; ignoring signal")
+                            self.signal_detected.remove(signal)
+                            continue
+
                         msg = f"ORDER SUBMITTED! {msg}"
                         if not self.args.real_trades:
                             msg = f"PAPER {msg}"


### PR DESCRIPTION
## Summary
- add pending order check before submitting an auto trade

## Testing
- `python -m py_compile src/spectr/spectr.py`


------
https://chatgpt.com/codex/tasks/task_e_6854b013f2dc832eaa1e2a556840f33c