### PR TITLE
Add OpenAI voice agent

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ rich~=14.0.0
 pytz
 fastparquet
 textual-web
+openai

--- a/src/spectr/agent.py
+++ b/src/spectr/agent.py
@@ -1,0 +1,50 @@
+import os
+import tempfile
+
+import openai
+import pygame
+import sounddevice as sd
+import soundfile as sf
+
+
+class VoiceAgent:
+    """Simple wrapper around OpenAI's voice features."""
+
+    def __init__(self, chat_model: str = "gpt-3.5-turbo", tts_model: str = "tts-1", voice: str = "nova") -> None:
+        openai.api_key = os.getenv("OPENAI_API_KEY")
+        self.chat_model = chat_model
+        self.tts_model = tts_model
+        self.voice = voice
+        pygame.mixer.init()
+
+    def say(self, text: str) -> None:
+        """Speak *text* using OpenAI text-to-speech."""
+        response = openai.audio.speech.create(
+            model=self.tts_model,
+            voice=self.voice,
+            input=text,
+        )
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".mp3") as f:
+            f.write(response.content)
+            fname = f.name
+        pygame.mixer.Sound(fname).play()
+
+    def listen_and_answer(self) -> str:
+        """Record a short audio question and reply with a spoken answer."""
+        duration = 5
+        sample_rate = 16_000
+        rec = sd.rec(int(duration * sample_rate), samplerate=sample_rate, channels=1)
+        sd.wait()
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as f:
+            sf.write(f.name, rec, sample_rate)
+            wav_path = f.name
+        with open(wav_path, "rb") as audio_file:
+            user_text = openai.Audio.transcribe("whisper-1", audio_file)["text"]
+        completion = openai.chat.completions.create(
+            model=self.chat_model,
+            messages=[{"role": "user", "content": user_text}],
+        )
+        reply = completion.choices[0].message.content
+        self.say(reply)
+        return reply
+

--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -40,6 +40,7 @@ from views.ticker_input_dialog import TickerInputDialog
 from views.top_overlay import TopOverlay
 from views.trades_screen import TradesScreen
 from views.strategy_screen import StrategyScreen
+from .agent import VoiceAgent
 
 
 
@@ -127,6 +128,7 @@ class SpectrApp(App):
         ("tab", "toggle_trades", "Trades Table"),
         ("p", "toggle_portfolio", "Portfolio"),
         ("s", "toggle_strategy_signals", "Strategy Signals"),
+        ("v", "ask_agent", "Voice Assistant"),
     ]
 
     ticker_symbols = reactive([])
@@ -206,6 +208,8 @@ class SpectrApp(App):
 
         self.trade_amount = 0.0
 
+        self.voice_agent = VoiceAgent()
+
         self.scanner_results: list[dict] = cache.load_scanner_cache()
         self.top_gainers: list[dict] = cache.load_gainers_cache()
 
@@ -268,9 +272,12 @@ class SpectrApp(App):
                 "reason": reason,
             },
         )
+        if signal:
+            self.voice_agent.say(f"{signal.capitalize()} signal for {symbol}")
 
     def on_mount(self):
         self.push_screen(SplashScreen(id="splash"), wait_for_dismiss=False)
+        self.voice_agent.say("Welcome to Spectr")
         self.refresh()
         # Set symbols and active symbol
         self.ticker_symbols = self.args.symbols
@@ -798,6 +805,11 @@ class SpectrApp(App):
                     self.set_strategy,
                 )
             )
+    def action_ask_agent(self) -> None:
+        if self._is_splash_active():
+            return
+        self.run_worker(self.voice_agent.listen_and_answer, thread=True)
+
 
 
     # ------------ Order Dialog Submit Logic -------------


### PR DESCRIPTION
## Summary
- create `VoiceAgent` to leverage OpenAI speech APIs
- integrate voice agent with app startup and signal notifications
- allow users to ask the agent questions with the `V` key
- add OpenAI to requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6854ed504650832ebf972dd113d4fc2c