### PR TITLE
Add scanner interface and selection dropdown

### DIFF
--- a/src/spectr/scanners/__init__.py
+++ b/src/spectr/scanners/__init__.py
@@ -1,0 +1,28 @@
+import importlib
+import inspect
+import pkgutil
+from typing import Type
+
+from .scanner_interface import ScannerInterface
+
+__all__ = ["load_scanner", "list_scanners", "ScannerInterface"]
+
+
+def list_scanners() -> dict[str, Type[ScannerInterface]]:
+    """Return mapping of scanner name to class found in this package."""
+    scanners: dict[str, Type[ScannerInterface]] = {}
+    package = __name__
+    for _, mod_name, _ in pkgutil.iter_modules(__path__):
+        module = importlib.import_module(f"{package}.{mod_name}")
+        for name, obj in inspect.getmembers(module, inspect.isclass):
+            if issubclass(obj, ScannerInterface) and obj is not ScannerInterface:
+                scanners[name] = obj
+    return scanners
+
+
+def load_scanner(name: str) -> Type[ScannerInterface]:
+    """Load scanner class by name from this package."""
+    scanners = list_scanners()
+    if name not in scanners:
+        raise ValueError(f"Scanner '{name}' not found")
+    return scanners[name]

--- a/src/spectr/scanners/scanner_interface.py
+++ b/src/spectr/scanners/scanner_interface.py
@@ -1,0 +1,26 @@
+from abc import ABC, abstractmethod
+
+class ScannerInterface(ABC):
+    """Abstract interface for background scanners."""
+
+    @abstractmethod
+    def __init__(self, data_api, exit_event) -> None:
+        """Initialize the scanner with data source and exit event."""
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def scanner_results(self) -> list[dict]:
+        """Return the latest filtered scan results."""
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def top_gainers(self) -> list[dict]:
+        """Return the latest unfiltered top gainers."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def scanner_loop(self, interval: float = 60.0) -> None:
+        """Continuously run the scanner every ``interval`` seconds."""
+        raise NotImplementedError


### PR DESCRIPTION
## Summary
- move `custom_scanner.py` into new `scanners` package
- create `ScannerInterface` and utilities to load scanners
- refactor `CustomScanner` to implement the interface
- integrate scanners into `SpectrApp` with ability to change scanner
- add dropdown menu in ticker input dialog for selecting scanners

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855760938c0832ebbd44d57d33db7b5