### PR TITLE
Add strategy name column to signals table

### DIFF
--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -287,6 +287,7 @@ class SpectrApp(App):
                 "side": signal,
                 "price": curr_price,
                 "reason": reason,
+                "strategy": self.strategy_name,
             },
         )
         if signal:

--- a/src/spectr/views/strategy_screen.py
+++ b/src/spectr/views/strategy_screen.py
@@ -23,7 +23,14 @@ class StrategyScreen(Screen):
 
     def compose(self):
         table = DataTable(zebra_stripes=True)
-        table.add_columns("Date/Time", "Symbol", "Side", "Price", "Reason")
+        table.add_columns(
+            "Date/Time",
+            "Symbol",
+            "Side",
+            "Price",
+            "Reason",
+            "Strategy",
+        )
         for sig in sorted(self.signals, key=lambda r: r.get("time") or datetime.min):
             dt_raw = sig.get("time")
             dt = dt_raw.strftime("%Y-%m-%d %H:%M") if dt_raw else ""
@@ -34,6 +41,7 @@ class StrategyScreen(Screen):
                 sig.get("side", "").upper(),
                 f"{price:.2f}" if price is not None else "",
                 sig.get("reason", ""),
+                sig.get("strategy", ""),
             )
 
         select = Select(


### PR DESCRIPTION
## Summary
- display the strategy name for each signal
- include the field when recording signals

## Testing
- `python -m py_compile src/spectr/spectr.py src/spectr/views/strategy_screen.py`

------
https://chatgpt.com/codex/tasks/task_e_68559a04bd98832ead82180c16e4df21