### PR TITLE
Sort strategy screen table by newest first

### DIFF
--- a/src/spectr/views/strategy_screen.py
+++ b/src/spectr/views/strategy_screen.py
@@ -31,7 +31,11 @@ class StrategyScreen(Screen):
             "Reason",
             "Strategy",
         )
-        for sig in sorted(self.signals, key=lambda r: r.get("time") or datetime.min):
+        for sig in sorted(
+            self.signals,
+            key=lambda r: r.get("time") or datetime.min,
+            reverse=True,
+        ):
             dt_raw = sig.get("time")
             dt = dt_raw.strftime("%Y-%m-%d %H:%M") if dt_raw else ""
             price = sig.get("price")


### PR DESCRIPTION
## Summary
- display newest strategy signals at the top of the strategy screen table

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855b51d1364832eb97c1a8e13685127