### PR TITLE
Add broker tools to voice agent

### DIFF
--- a/src/spectr/agent.py
+++ b/src/spectr/agent.py
@@ -10,22 +10,248 @@ import pygame
 import sounddevice as sd
 import soundfile as sf
 
+import pandas as pd
+
 from news import get_latest_news
+from fetch.broker_interface import BrokerInterface, OrderSide, OrderType
 
 
 class VoiceAgent:
     """Simple wrapper around OpenAI's voice features."""
 
-    def __init__(self, chat_model: str = "gpt-3.5-turbo", tts_model: str = "tts-1-hd", voice: str = "sage") -> None:
+    def __init__(
+        self,
+        broker_api: BrokerInterface | None = None,
+        chat_model: str = "gpt-3.5-turbo",
+        tts_model: str = "tts-1-hd",
+        voice: str = "sage",
+    ) -> None:
         """Initialize the voice agent and OpenAI client."""
         self.client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
         self.chat_model = chat_model
         self.tts_model = tts_model
         self.voice = voice
+        self.broker = broker_api
         pygame.mixer.init()
         self._queue: queue.Queue[str] = queue.Queue()
         self._worker = threading.Thread(target=self._speech_worker, daemon=True)
         self._worker.start()
+
+        self.tools = self._build_tools()
+        self.tool_funcs = self._build_tool_funcs()
+
+    def _serialize(self, obj):
+        if obj is None:
+            return None
+        if isinstance(obj, pd.DataFrame):
+            return obj.to_dict(orient="records")
+        if isinstance(obj, (list, tuple)):
+            return [self._serialize(o) for o in obj]
+        if hasattr(obj, "model_dump"):
+            try:
+                return obj.model_dump()
+            except Exception:
+                pass
+        if hasattr(obj, "__dict__"):
+            return {k: v for k, v in vars(obj).items() if not k.startswith("_")}
+        return obj
+
+    def _build_tools(self) -> list:
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_latest_news",
+                    "description": "Fetch the most recent news article for a stock symbol",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "symbol": {"type": "string", "description": "Stock ticker"}
+                        },
+                        "required": ["symbol"],
+                    },
+                },
+            },
+        ]
+
+        if self.broker:
+            tools.extend([
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_balance",
+                        "description": "Return account balance information",
+                        "parameters": {"type": "object", "properties": {}, "required": []},
+                    },
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "has_pending_order",
+                        "description": "Check if there is a pending order for a symbol",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "symbol": {"type": "string", "description": "Ticker symbol"}
+                            },
+                            "required": ["symbol"],
+                        },
+                    },
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_pending_orders",
+                        "description": "Fetch pending orders for a symbol",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "symbol": {"type": "string", "description": "Ticker symbol"}
+                            },
+                            "required": ["symbol"],
+                        },
+                    },
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_closed_orders",
+                        "description": "Fetch all closed orders",
+                        "parameters": {"type": "object", "properties": {}, "required": []},
+                    },
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_all_orders",
+                        "description": "Fetch all orders on the account",
+                        "parameters": {"type": "object", "properties": {}, "required": []},
+                    },
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_orders_for_symbol",
+                        "description": "Fetch all orders for a symbol",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "symbol": {"type": "string", "description": "Ticker symbol"}
+                            },
+                            "required": ["symbol"],
+                        },
+                    },
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "has_position",
+                        "description": "Check if a position exists for a symbol",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "symbol": {"type": "string", "description": "Ticker symbol"}
+                            },
+                            "required": ["symbol"],
+                        },
+                    },
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_position",
+                        "description": "Fetch position details for a symbol",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "symbol": {"type": "string", "description": "Ticker symbol"}
+                            },
+                            "required": ["symbol"],
+                        },
+                    },
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_positions",
+                        "description": "Fetch all open positions",
+                        "parameters": {"type": "object", "properties": {}, "required": []},
+                    },
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "submit_order",
+                        "description": "Submit an order",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "symbol": {"type": "string"},
+                                "side": {"type": "string", "description": "BUY or SELL"},
+                                "type": {"type": "string", "description": "MARKET or LIMIT"},
+                                "quantity": {"type": "number"},
+                                "limit_price": {"type": "number"},
+                                "market_price": {"type": "number"},
+                            },
+                            "required": ["symbol", "side", "type"],
+                        },
+                    },
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "cancel_order",
+                        "description": "Cancel an existing order",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "order_id": {"type": "string"}
+                            },
+                            "required": ["order_id"],
+                        },
+                    },
+                },
+            ])
+
+        return tools
+
+    def _build_tool_funcs(self) -> dict:
+        funcs = {
+            "get_latest_news": get_latest_news,
+        }
+
+        if not self.broker:
+            return funcs
+
+        funcs.update(
+            {
+                "get_balance": lambda: json.dumps(self._serialize(self.broker.get_balance())),
+                "has_pending_order": lambda symbol: json.dumps(self.broker.has_pending_order(symbol)),
+                "get_pending_orders": lambda symbol: json.dumps(self._serialize(self.broker.get_pending_orders(symbol))),
+                "get_closed_orders": lambda: json.dumps(self._serialize(self.broker.get_closed_orders())),
+                "get_all_orders": lambda: json.dumps(self._serialize(self.broker.get_all_orders())),
+                "get_orders_for_symbol": lambda symbol: json.dumps(self._serialize(self.broker.get_orders_for_symbol(symbol))),
+                "has_position": lambda symbol: json.dumps(self.broker.has_position(symbol)),
+                "get_position": lambda symbol: json.dumps(self._serialize(self.broker.get_position(symbol))),
+                "get_positions": lambda: json.dumps(self._serialize(self.broker.get_positions())),
+                "submit_order": lambda symbol, side, type, quantity=None, limit_price=None, market_price=None: json.dumps(
+                    self._serialize(
+                        self.broker.submit_order(
+                            symbol=symbol,
+                            side=OrderSide[side.upper()],
+                            type=OrderType[type.upper()],
+                            quantity=quantity,
+                            limit_price=limit_price,
+                            market_price=market_price,
+                            real_trades=self.broker.real_trades,
+                        )
+                    )
+                ),
+                "cancel_order": lambda order_id: json.dumps(self._serialize(self.broker.cancel_order(order_id))),
+            }
+        )
+
+        return funcs
 
     def say(self, text: str) -> None:
         """Queue *text* to be spoken using OpenAI text-to-speech."""
@@ -77,22 +303,7 @@ class VoiceAgent:
             user_text = transcription.text
 
         messages = [{"role": "user", "content": user_text}]
-        tools = [
-            {
-                "type": "function",
-                "function": {
-                    "name": "get_latest_news",
-                    "description": "Fetch the most recent news article for a stock symbol",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "symbol": {"type": "string", "description": "Stock ticker"}
-                        },
-                        "required": ["symbol"],
-                    },
-                },
-            }
-        ]
+        tools = self.tools
 
         completion = self.client.chat.completions.create(
             model=self.chat_model,
@@ -104,9 +315,10 @@ class VoiceAgent:
         if message.tool_calls:
             messages.append(message.model_dump())
             for call in message.tool_calls:
-                if call.function.name == "get_latest_news":
+                func = self.tool_funcs.get(call.function.name)
+                if func:
                     args = json.loads(call.function.arguments)
-                    result = get_latest_news(**args)
+                    result = func(**args)
                     messages.append({
                         "role": "tool",
                         "tool_call_id": call.id,

--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -215,7 +215,7 @@ class SpectrApp(App):
 
         self.trade_amount = 0.0
 
-        self.voice_agent = VoiceAgent()
+        self.voice_agent = VoiceAgent(broker_api=BROKER_API)
 
         # Available background scanners
         self.available_scanners = list_scanners()


### PR DESCRIPTION
## Summary
- let VoiceAgent accept broker interface
- expose broker operations to the OpenAI function-calling API
- wire SpectrApp to provide the broker when creating VoiceAgent

## Testing
- `python -m compileall -q src/spectr`
- `python src/spectr/spectr.py --help` *(fails: No module named 'backtrader')*

------
https://chatgpt.com/codex/tasks/task_e_685611b8e62c832ea71e7cafd172095c