### PR TITLE
Add wake-word driven real time voice agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ BYOS - Bring Your Own Strategy. You must implement your own trading strategy in 
 - 🔁 Backtest mode with visual result playback with `b`.
 - 🎤 Experimental voice agent that can answer questions and fetch the latest
   news for a stock symbol.
+- 🎤 Optional real-time mode listens for the wake word "spectr". Enable with
+  `--voice_agent_listen`.
 
 ---
 
@@ -102,6 +104,8 @@ python -m spectr --broker alpaca --data_api fmp --scale 0.5 --symbols NVDA,TSLA,
 | `--take_profit_pct` | Take profit percent.                                    |
 | `--scale`           | Scale the terminal UI (default: 0.5)                    |
 | `--candles`         | Enable candle chart mode (default: on).                               |
+| `--voice_agent_listen` | Enable real-time voice agent listening for the wake word. |
+| `--voice_agent_wake_word` | Word that triggers the voice agent (default: spectr). |
 
 ---------------
 ### Ticker Select Dialog with Scanner. Select rows to add to watchlist:

--- a/src/spectr/agent.py
+++ b/src/spectr/agent.py
@@ -40,6 +40,10 @@ class VoiceAgent:
         self.tools = self._build_tools()
         self.tool_funcs = self._build_tool_funcs()
 
+        self.wake_word = "spectr"
+        self._wake_event: threading.Event | None = None
+        self._listen_thread: threading.Thread | None = None
+
     def _serialize(self, obj):
         """Recursively convert *obj* into JSON serialisable primitives."""
         if obj is None:
@@ -348,4 +352,47 @@ class VoiceAgent:
 
         self.say(reply)
         return reply
+
+    # ------------------------------------------------------------------
+    # Real-time listening for a wake word
+    # ------------------------------------------------------------------
+    def start_wake_word_listener(self, wake_word: str = "spectr") -> None:
+        """Begin a background thread listening for *wake_word*."""
+        if self._listen_thread and self._listen_thread.is_alive():
+            return
+
+        self.wake_word = wake_word.lower()
+        self._wake_event = threading.Event()
+        self._listen_thread = threading.Thread(
+            target=self._wake_word_loop, daemon=True
+        )
+        self._listen_thread.start()
+
+    def stop_wake_word_listener(self) -> None:
+        """Stop the background wake word listener."""
+        if self._wake_event:
+            self._wake_event.set()
+        if self._listen_thread and self._listen_thread.is_alive():
+            self._listen_thread.join(timeout=1.0)
+
+    def _wake_word_loop(self) -> None:
+        sample_rate = 16_000
+        duration = 2
+        while not self._wake_event.is_set():
+            rec = sd.rec(int(duration * sample_rate), samplerate=sample_rate, channels=1)
+            sd.wait()
+            with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as f:
+                sf.write(f.name, rec, sample_rate)
+                wav_path = f.name
+            try:
+                with open(wav_path, "rb") as audio_file:
+                    transcription = self.client.audio.transcriptions.create(
+                        model="whisper-1", file=audio_file
+                    )
+                text = transcription.text.lower()
+                if self.wake_word in text:
+                    self.say("Yes?")
+                    self.listen_and_answer()
+            except Exception:
+                pass
 

--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -216,6 +216,10 @@ class SpectrApp(App):
         self.trade_amount = 0.0
 
         self.voice_agent = VoiceAgent(broker_api=BROKER_API)
+        if getattr(args, "voice_agent_listen", False):
+            self.voice_agent.start_wake_word_listener(
+                getattr(args, "voice_agent_wake_word", "spectr")
+            )
 
         # Available background scanners
         self.available_scanners = list_scanners()
@@ -527,6 +531,8 @@ class SpectrApp(App):
             log.debug("cancelling equity worker")
             self._equity_worker.cancel()
             self._equity_worker = None
+
+        self.voice_agent.stop_wake_word_listener()
 
         if self._consumer_task:
             log.debug("cancelling consumer task")
@@ -1163,6 +1169,16 @@ def main() -> None:
         choices=["alpaca", "robinhood", "fmp"],
         default="robinhood",
         help="Choose which data provider to use (Alpaca, Robinhood, or FMP)",
+    )
+    parser.add_argument(
+        "--voice_agent_listen",
+        action="store_true",
+        help="Enable real-time voice agent listening for a wake word",
+    )
+    parser.add_argument(
+        "--voice_agent_wake_word",
+        default="spectr",
+        help="Wake word that triggers the voice agent",
     )
     parser.add_argument("--debug", action="store_true")
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
- make Spectr voice agent listen for a wake word
- allow enabling real time voice agent with CLI flags
- stop the listener on shutdown
- document new feature in README

## Testing
- `python -m py_compile src/spectr/agent.py src/spectr/spectr.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685624a2eb00832eb9f303952b8c8275