### PR TITLE
Fix JSON serialization bug in voice agent

### DIFF
--- a/src/spectr/agent.py
+++ b/src/spectr/agent.py
@@ -63,7 +63,7 @@ class VoiceAgent:
             pass
         if hasattr(obj, "model_dump"):
             try:
-                return obj.model_dump()
+                return self._serialize(obj.model_dump())
             except Exception:
                 pass
         if hasattr(obj, "__dict__"):


### PR DESCRIPTION
## Summary
- serialize `model_dump` objects recursively to handle `UUID` values

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685628445c20832e9e3109ede87cc2ed