### PR TITLE
Add data API tools for voice agent

### DIFF
--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -215,7 +215,7 @@ class SpectrApp(App):
 
         self.trade_amount = 0.0
 
-        self.voice_agent = VoiceAgent(broker_api=BROKER_API)
+        self.voice_agent = VoiceAgent(broker_api=BROKER_API, data_api=DATA_API)
         if getattr(args, "voice_agent_listen", False):
             self.voice_agent.start_wake_word_listener(
                 getattr(args, "voice_agent_wake_word", "spectr")


### PR DESCRIPTION
## Summary
- extend `VoiceAgent` to accept a data API
- expose new functions in the agent for company profile, quote, bid/ask, float, volume and chart data
- hook up Spectr app to provide the data API to the agent

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -e .`
- `pip check`


------
https://chatgpt.com/codex/tasks/task_e_68562792a7a8832e95fd6bad1f307464