### PR TITLE
Hold splash screen until voice greeting finishes

### DIFF
--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -306,7 +306,7 @@ class SpectrApp(App):
 
     def on_mount(self):
         self.push_screen(SplashScreen(id="splash"), wait_for_dismiss=False)
-        self.voice_agent.say("Welcome to Spectr")
+        self.voice_agent.say("Welcome to Spectr", wait=True)
         self.refresh()
         # Set symbols and active symbol
         self.ticker_symbols = self.args.symbols


### PR DESCRIPTION
## Summary
- keep welcome screen visible until the voice agent completes speaking
- allow `VoiceAgent.say()` to wait for speech completion

## Testing
- `python -m py_compile src/spectr/agent.py src/spectr/spectr.py`

------
https://chatgpt.com/codex/tasks/task_e_685632706360832e842ad0331f26d7bb