### PR TITLE
Handle API rate limiting in voice agent

### DIFF
--- a/src/spectr/exceptions.py
+++ b/src/spectr/exceptions.py
@@ -1,0 +1,3 @@
+class DataApiRateLimitError(Exception):
+    """Raised when a data API responds with HTTP 429."""
+    pass


### PR DESCRIPTION
## Summary
- raise a custom `DataApiRateLimitError` when FMP responds with HTTP 429
- check for HTTP 429 in all FMP data fetchers
- handle rate limit errors in `VoiceAgent.listen_and_answer`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68564f6561e4832ea592e161eade7e5e