### PR TITLE
Expose cached orders to VoiceAgent

### DIFF
--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -215,7 +215,11 @@ class SpectrApp(App):
 
         self.trade_amount = 0.0
 
-        self.voice_agent = VoiceAgent(broker_api=BROKER_API, data_api=DATA_API)
+        self.voice_agent = VoiceAgent(
+            broker_api=BROKER_API,
+            data_api=DATA_API,
+            get_cached_orders=lambda: self._portfolio_orders_cache,
+        )
         if getattr(args, "voice_agent_listen", False):
             self.voice_agent.start_wake_word_listener(
                 getattr(args, "voice_agent_wake_word", "spectr")


### PR DESCRIPTION
## Summary
- allow VoiceAgent to accept a callable for retrieving cached orders
- expose a new `get_cached_orders` tool
- pass Spectr's cached order list into VoiceAgent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68566429b100832e9e674a70a9cd0b64