### PR TITLE
Add scanner and gainers cache tools

### DIFF
--- a/src/spectr/agent.py
+++ b/src/spectr/agent.py
@@ -13,6 +13,8 @@ import requests
 
 import pandas as pd
 
+import cache
+
 from news import get_latest_news
 from fetch.broker_interface import BrokerInterface, OrderSide, OrderType
 from spectr.exceptions import DataApiRateLimitError
@@ -110,6 +112,22 @@ class VoiceAgent:
                         },
                         "required": ["symbol"],
                     },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_scanner_cache",
+                    "description": "Return cached scanner results",
+                    "parameters": {"type": "object", "properties": {}, "required": []},
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_gainers_cache",
+                    "description": "Return cached top gainers data",
+                    "parameters": {"type": "object", "properties": {}, "required": []},
                 },
             },
         ]
@@ -350,6 +368,12 @@ class VoiceAgent:
     def _build_tool_funcs(self) -> dict:
         funcs = {
             "get_latest_news": get_latest_news,
+            "get_scanner_cache": lambda: json.dumps(
+                self._serialize(cache.load_scanner_cache())
+            ),
+            "get_gainers_cache": lambda: json.dumps(
+                self._serialize(cache.load_gainers_cache())
+            ),
         }
 
         if self.data_api:


### PR DESCRIPTION
## Summary
- import `cache` in `agent`
- expose new `get_scanner_cache` and `get_gainers_cache` tools
- map new tools to cache loader functions

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685665f56df0832ebf177e8ce3d11242