### PR TITLE
Fix relative import and missing dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
   "textual>=0.59",
   "pandas>=2.2",
   "requests>=2.32",
+  "tzlocal>=5.0",
   # add anything else used: numpy, plotext, etc.
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ pytz~=2025.2
 numpy~=2.2.5
 ta~=0.11.0
 python-dotenv~=1.1.0
+tzlocal~=5.2
 textual
 plotext~=5.3.2
 requests~=2.32.3

--- a/src/spectr/fetch/alpaca.py
+++ b/src/spectr/fetch/alpaca.py
@@ -14,7 +14,7 @@ from alpaca.trading import (
 from dotenv import load_dotenv
 
 from .broker_interface import BrokerInterface, OrderType
-from utils import is_crypto_symbol
+from ..utils import is_crypto_symbol
 
 # Loading from .env file, you need to create one and define both ALPACA_API_KEY and ALPACA_SECRET_KEY
 load_dotenv()


### PR DESCRIPTION
## Summary
- fix utils import in alpaca broker
- add tzlocal to dependencies to avoid missing module errors

## Testing
- `python -m pip install -e .`
- `python -m spectr.spectr --help` *(fails: ModuleNotFoundError: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_685736927d38832e8618e2e3445186de