### PR TITLE
Fix import error in FMP data provider

### DIFF
--- a/src/spectr/fetch/fmp.py
+++ b/src/spectr/fetch/fmp.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta, timezone
 from tzlocal import get_localzone
 
 from .data_interface import DataInterface
-from exceptions import DataApiRateLimitError
+from ..exceptions import DataApiRateLimitError
 
 load_dotenv()
 FMP_API_KEY = os.getenv("FMP_API_KEY")


### PR DESCRIPTION
## Summary
- fix a module import typo in `fetch/fmp.py`

## Testing
- `pip check`

------
https://chatgpt.com/codex/tasks/task_e_68573bb0a33c832ebe13a3fb8eb05092