### PR TITLE
Add onboarding dialog for broker and data provider

### DIFF
--- a/src/spectr/cache.py
+++ b/src/spectr/cache.py
@@ -157,3 +157,20 @@ def load_selected_scanner(path: pathlib.Path = SCANNER_NAME_FILE) -> str | None:
         return json.loads(path.read_text())
     except Exception:
         return None
+ONBOARD_FILE = pathlib.Path.home() / ".spectr_onboard.json"
+
+
+def save_onboarding_config(config: dict, path: pathlib.Path = ONBOARD_FILE) -> None:
+    """Persist onboarding configuration."""
+    try:
+        path.write_text(json.dumps(config))
+    except Exception as exc:
+        log.error(f"onboarding cache write failed: {exc}")
+
+
+def load_onboarding_config(path: pathlib.Path = ONBOARD_FILE) -> dict | None:
+    """Load onboarding configuration if present."""
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return None

--- a/src/spectr/views/onboarding_app.py
+++ b/src/spectr/views/onboarding_app.py
@@ -1,0 +1,23 @@
+from textual.app import App
+
+from .onboarding_dialog import OnboardingDialog
+
+class OnboardingApp(App):
+    """Temporary app to collect onboarding information."""
+    CSS_PATH = "default.tcss"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.result = None
+
+    async def on_mount(self) -> None:
+        await self.push_screen(OnboardingDialog(self._on_submit), wait_for_dismiss=False)
+
+    def _on_submit(self, broker: str, data: str, broker_key: str, data_key: str) -> None:
+        self.result = {
+            "broker": broker,
+            "data_api": data,
+            "broker_key": broker_key,
+            "data_key": data_key,
+        }
+        self.exit()

--- a/src/spectr/views/onboarding_dialog.py
+++ b/src/spectr/views/onboarding_dialog.py
@@ -1,0 +1,47 @@
+from textual.screen import ModalScreen
+from textual.widgets import Static, Input, Button, Label, Select
+from textual.app import ComposeResult
+from textual.message import Message
+
+class OnboardingDialog(ModalScreen):
+    """Ask the user for broker and data provider configuration."""
+
+    BINDINGS = [
+        ("enter", "save", "Save"),
+        ("escape", "app.pop_screen", "Cancel"),
+    ]
+
+    class Submit(Message):
+        def __init__(self, sender: "OnboardingDialog", *, broker: str, data: str, broker_key: str, data_key: str) -> None:
+            super().__init__()
+            self.broker = broker
+            self.data = data
+            self.broker_key = broker_key
+            self.data_key = data_key
+
+    def __init__(self, callback) -> None:
+        super().__init__()
+        self._callback = callback
+
+    def compose(self) -> ComposeResult:
+        yield Static("Initial Setup", classes="title")
+        yield Label("Broker:")
+        yield Select(id="broker-select", options=[("Alpaca", "alpaca"), ("Robinhood", "robinhood")])
+        yield Input(placeholder="Broker API Key", id="broker-key")
+        yield Label("Data Provider:")
+        yield Select(id="data-select", options=[("Alpaca", "alpaca"), ("Robinhood", "robinhood"), ("FMP", "fmp")])
+        yield Input(placeholder="Data API Key", id="data-key")
+        yield Button("Save", id="save", variant="success")
+        yield Button("Cancel", id="cancel", variant="error")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "save":
+            broker = self.query_one("#broker-select", Select).value
+            data = self.query_one("#data-select", Select).value
+            broker_key = self.query_one("#broker-key", Input).value
+            data_key = self.query_one("#data-key", Input).value
+            self.dismiss()
+            if self._callback:
+                self._callback(broker, data, broker_key, data_key)
+        else:
+            self.dismiss()


### PR DESCRIPTION
## Summary
- show a new onboarding dialog if broker and data provider aren't specified
- persist onboarding config in a cache file
- load onboarding config on startup

## Testing
- `python -m py_compile src/spectr/views/onboarding_app.py src/spectr/views/onboarding_dialog.py src/spectr/cache.py src/spectr/spectr.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857531bb250832eb6b1fd42a7ca0ded