### PR TITLE
Fix onboarding app CSS path

### DIFF
--- a/src/spectr/views/onboarding_app.py
+++ b/src/spectr/views/onboarding_app.py
@@ -1,10 +1,11 @@
+from pathlib import Path
 from textual.app import App
 
 from .onboarding_dialog import OnboardingDialog
 
 class OnboardingApp(App):
     """Temporary app to collect onboarding information."""
-    CSS_PATH = "default.tcss"
+    CSS_PATH = Path(__file__).resolve().parent.parent / "default.tcss"
 
     def __init__(self) -> None:
         super().__init__()


### PR DESCRIPTION
## Summary
- make onboarding app load default stylesheet from project root

## Testing
- `pip install -r requirements.txt`
- `pip check`


------
https://chatgpt.com/codex/tasks/task_e_68583d051b94832ebfdd0ccc92694db4