### PR TITLE
Fix onboarding exit and styling

### DIFF
--- a/src/spectr/default.tcss
+++ b/src/spectr/default.tcss
@@ -172,6 +172,32 @@ OrderDialog {
     margin: 2 2;
 }
 
+/* ------- Onboarding Dialog ------- */
+
+OnboardingDialog {
+    align: center middle;
+}
+
+#onboarding_body {
+    width: 70%;
+    border: solid green;
+    padding: 1 2;
+    content-align-horizontal: center;
+    background: #1a1a1a;
+}
+
+#onboarding_body Label,
+#onboarding_body Input,
+#onboarding_body Select,
+#onboarding_body Button {
+    padding: 1 1;
+}
+
+#onboarding_buttons_row {
+    width: 100%;
+    content-align-horizontal: center;
+}
+
 
 
 /* ------- Portfolio Screen ------- */


### PR DESCRIPTION
## Summary
- exit the app when onboarding is cancelled
- style onboarding dialog like other dialogs
- set onboarding dialog width to 70% and add spacing

## Testing
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_6858d8c4f9ec832eb1f4f8f2161fe3a3