### PR TITLE
Adjust onboarding dialog layout

### DIFF
--- a/src/spectr/default.tcss
+++ b/src/spectr/default.tcss
@@ -175,7 +175,7 @@ OrderDialog {
 /* ------- Onboarding Dialog ------- */
 
 OnboardingDialog {
-    align: center middle;
+    align: center top;
 }
 
 #onboarding_body {
@@ -183,7 +183,17 @@ OnboardingDialog {
     border: solid green;
     padding: 1 2;
     content-align-horizontal: center;
+    content-align-vertical: top;
+    height: 100%;
+    overflow: auto;
     background: #1a1a1a;
+}
+
+#onboarding-title {
+    text-align: center;
+    padding: 0 1;
+    width: 100%;
+    height: 3;
 }
 
 #onboarding_body Label,

--- a/src/spectr/views/onboarding_dialog.py
+++ b/src/spectr/views/onboarding_dialog.py
@@ -1,6 +1,6 @@
 from textual.screen import ModalScreen
 from textual.widgets import Static, Input, Button, Label, Select
-from textual.containers import Vertical, Horizontal
+from textual.containers import Vertical, Horizontal, VerticalScroll
 from textual.app import ComposeResult
 from textual.message import Message
 from textual import events
@@ -46,8 +46,8 @@ class OnboardingDialog(ModalScreen):
         self._callback = callback
 
     def compose(self) -> ComposeResult:
-        yield Vertical(
-            Static("Onboarding", classes="title"),
+        yield VerticalScroll(
+            Static("Onboarding", id="onboarding-title"),
             Label("Broker:"),
             Select(id="broker-select", options=[("Alpaca", "alpaca"), ("Robinhood", "robinhood")]),
             Input(placeholder="Broker API Key", id="broker-key"),


### PR DESCRIPTION
## Summary
- use `VerticalScroll` so the onboarding dialog can scroll
- keep the dialog aligned to the top of the screen
- ensure the onboarding title is centered
- allow onboarding body to scroll when its content exceeds the screen

## Testing
- `python -m compileall -q src/spectr`

------
https://chatgpt.com/codex/tasks/task_e_6858eb861cb0832e88bdea57afb0e1b4