### PR TITLE
Add setup screen with confirm and UI tweaks

### DIFF
--- a/src/spectr/default.tcss
+++ b/src/spectr/default.tcss
@@ -172,13 +172,13 @@ OrderDialog {
     margin: 2 2;
 }
 
-/* ------- Onboarding Dialog ------- */
+/* ------- Setup Dialog ------- */
 
-OnboardingDialog {
+SetupDialog {
     align: center top;
 }
 
-#onboarding_body {
+#setup_body {
     width: 70%;
     border: solid green;
     padding: 1 2;
@@ -189,21 +189,21 @@ OnboardingDialog {
     background: #1a1a1a;
 }
 
-#onboarding-title {
+#setup-title {
     text-align: center;
     padding: 0 1;
     width: 100%;
     height: 3;
 }
 
-#onboarding_body Label,
-#onboarding_body Input,
-#onboarding_body Select,
-#onboarding_body Button {
+#setup_body Label,
+#setup_body Input,
+#setup_body Select,
+#setup_body Button {
     padding: 1 1;
 }
 
-#onboarding_buttons_row {
+#setup_buttons_row {
     width: 100%;
     content-align-horizontal: center;
 }

--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -42,7 +42,7 @@ from .views.splash_screen import SplashScreen
 from .views.strategy_screen import StrategyScreen
 from .views.symbol_view import SymbolView
 from .views.ticker_input_dialog import TickerInputDialog
-from .views.onboarding_app import OnboardingApp
+from .views.setup_app import SetupApp
 from .views.top_overlay import TopOverlay
 from .views.trades_screen import TradesScreen
 
@@ -1143,28 +1143,28 @@ def main() -> None:
             os.environ.setdefault("DATA_PROVIDER", cfg.get("data_api", ""))
 
     if not args.broker or not args.data_api:
-        onboarding = OnboardingApp()
-        onboarding.run()
-        if onboarding.result:
-            cache.save_onboarding_config(onboarding.result)
-            args.broker = onboarding.result.get("broker")
-            args.data_api = onboarding.result.get("data_api")
-            os.environ["PAPER_API_KEY"] = onboarding.result.get("paper_key", "")
-            os.environ["PAPER_SECRET"] = onboarding.result.get("paper_secret", "")
-            if onboarding.result.get("broker_key"):
-                os.environ["BROKER_API_KEY"] = onboarding.result["broker_key"]
-            if onboarding.result.get("broker_secret"):
-                os.environ["BROKER_SECRET"] = onboarding.result["broker_secret"]
-            if onboarding.result.get("data_key"):
-                os.environ["DATA_API_KEY"] = onboarding.result["data_key"]
-            if onboarding.result.get("data_secret"):
-                os.environ["DATA_SECRET"] = onboarding.result["data_secret"]
-            if onboarding.result.get("openai_key"):
-                os.environ["OPENAI_API_KEY"] = onboarding.result["openai_key"]
-            if onboarding.result.get("data_api"):
-                os.environ["DATA_PROVIDER"] = onboarding.result["data_api"]
+        setup = SetupApp()
+        setup.run()
+        if setup.result:
+            cache.save_onboarding_config(setup.result)
+            args.broker = setup.result.get("broker")
+            args.data_api = setup.result.get("data_api")
+            os.environ["PAPER_API_KEY"] = setup.result.get("paper_key", "")
+            os.environ["PAPER_SECRET"] = setup.result.get("paper_secret", "")
+            if setup.result.get("broker_key"):
+                os.environ["BROKER_API_KEY"] = setup.result["broker_key"]
+            if setup.result.get("broker_secret"):
+                os.environ["BROKER_SECRET"] = setup.result["broker_secret"]
+            if setup.result.get("data_key"):
+                os.environ["DATA_API_KEY"] = setup.result["data_key"]
+            if setup.result.get("data_secret"):
+                os.environ["DATA_SECRET"] = setup.result["data_secret"]
+            if setup.result.get("openai_key"):
+                os.environ["OPENAI_API_KEY"] = setup.result["openai_key"]
+            if setup.result.get("data_api"):
+                os.environ["DATA_PROVIDER"] = setup.result["data_api"]
         else:
-            print("Onboarding cancelled.")
+            print("Setup cancelled.")
             return
     else:
         # If the user provided CLI options, ensure DATA_PROVIDER is set

--- a/src/spectr/views/portfolio_screen.py
+++ b/src/spectr/views/portfolio_screen.py
@@ -3,7 +3,7 @@ import logging
 from typing import Optional
 
 from textual.screen import Screen
-from textual.widgets import Static, DataTable, Switch, Input
+from textual.widgets import Static, DataTable, Switch, Input, Button
 from textual.containers import Vertical, Container, Horizontal
 from textual.reactive import reactive
 from textual import events
@@ -13,6 +13,8 @@ from ..fetch.broker_interface import OrderSide
 import asyncio
 
 from .equity_curve_view import EquityCurveView
+from .setup_confirm_dialog import SetupConfirmDialog
+from .setup_app import SetupApp
 
 log = logging.getLogger(__name__)
 
@@ -216,6 +218,7 @@ class PortfolioScreen(Screen):
             self.holdings_table,
             Static("Order History:", id="orders-title"),
             self.order_table,
+            Button("Setup", id="setup-button"),
             id="portfolio-screen",
         )
 
@@ -444,3 +447,10 @@ class PortfolioScreen(Screen):
             "done_for_day",
         }
         return status not in not_cancelable
+
+    async def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "setup-button":
+            result = await self.app.push_screen(SetupConfirmDialog(), wait_for_dismiss=True)
+            if result:
+                setup = SetupApp()
+                setup.run()

--- a/src/spectr/views/setup_app.py
+++ b/src/spectr/views/setup_app.py
@@ -1,10 +1,10 @@
 from pathlib import Path
 from textual.app import App
 
-from .onboarding_dialog import OnboardingDialog
+from .setup_dialog import SetupDialog
 
-class OnboardingApp(App):
-    """Temporary app to collect onboarding information."""
+class SetupApp(App):
+    """Temporary app to collect setup information."""
     CSS_PATH = Path(__file__).resolve().parent.parent / "default.tcss"
 
     def __init__(self) -> None:
@@ -12,7 +12,7 @@ class OnboardingApp(App):
         self.result = None
 
     async def on_mount(self) -> None:
-        await self.push_screen(OnboardingDialog(self._on_submit), wait_for_dismiss=False)
+        await self.push_screen(SetupDialog(self._on_submit), wait_for_dismiss=False)
 
     def _on_submit(
         self,

--- a/src/spectr/views/setup_confirm_dialog.py
+++ b/src/spectr/views/setup_confirm_dialog.py
@@ -1,0 +1,28 @@
+from textual.screen import ModalScreen
+from textual.widgets import Static, Button
+from textual.containers import Vertical, Horizontal
+from textual.app import ComposeResult
+from textual.message import Message
+
+class SetupConfirmDialog(ModalScreen):
+    """Simple yes/no confirmation dialog for setup."""
+
+    class Result(Message):
+        def __init__(self, sender: "SetupConfirmDialog", value: bool) -> None:
+            super().__init__()
+            self.value = value
+
+    def compose(self) -> ComposeResult:
+        yield Vertical(
+            Static("Reconfigure API keys?"),
+            Horizontal(
+                Button("Yes", id="yes", variant="success"),
+                Button("No", id="no", variant="error"),
+                id="setup_confirm_row",
+            ),
+            id="setup_confirm_body",
+        )
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        self.dismiss(event.button.id == "yes")
+

--- a/src/spectr/views/setup_dialog.py
+++ b/src/spectr/views/setup_dialog.py
@@ -5,7 +5,7 @@ from textual.app import ComposeResult
 from textual.message import Message
 from textual import events
 
-class OnboardingDialog(ModalScreen):
+class SetupDialog(ModalScreen):
     """Ask the user for broker and data provider configuration."""
 
     BINDINGS = [
@@ -16,7 +16,7 @@ class OnboardingDialog(ModalScreen):
     class Submit(Message):
         def __init__(
             self,
-            sender: "OnboardingDialog",
+            sender: "SetupDialog",
             *,
             broker: str,
             paper: str,
@@ -47,7 +47,7 @@ class OnboardingDialog(ModalScreen):
 
     def compose(self) -> ComposeResult:
         yield VerticalScroll(
-            Static("Onboarding", id="onboarding-title"),
+            Static("Setup", id="setup-title"),
             Label("Broker:"),
             Select(id="broker-select", options=[("Alpaca", "alpaca"), ("Robinhood", "robinhood")]),
             Input(placeholder="Broker API Key", id="broker-key"),
@@ -65,9 +65,9 @@ class OnboardingDialog(ModalScreen):
             Horizontal(
                 Button("Save", id="save", variant="success"),
                 Button("Cancel", id="cancel", variant="error"),
-                id="onboarding_buttons_row",
+                id="setup_buttons_row",
             ),
-            id="onboarding_body",
+            id="setup_body",
         )
 
     async def on_mount(self, event: events.Mount) -> None:


### PR DESCRIPTION
## Summary
- rename onboarding UI to setup
- allow re-running setup from portfolio screen via button
- ask user to confirm before running setup

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6859042d7810832e9d465bea9b52662f