### PR TITLE
Add Close button to portfolio screen

### DIFF
--- a/src/spectr/views/portfolio_screen.py
+++ b/src/spectr/views/portfolio_screen.py
@@ -218,6 +218,7 @@ class PortfolioScreen(Screen):
             self.holdings_table,
             Static("Order History:", id="orders-title"),
             self.order_table,
+            Button("Close", id="close-button", variant="error"),
             Button("Setup", id="setup-button"),
             id="portfolio-screen",
         )
@@ -454,3 +455,5 @@ class PortfolioScreen(Screen):
             if result:
                 setup = SetupApp()
                 setup.run()
+        elif event.button.id == "close-button":
+            self.app.pop_screen()


### PR DESCRIPTION
## Summary
- add a Close button to allow exiting the Portfolio screen

## Testing
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_6859a5311bf8832ea5a5c1ee396b40f7