### PR TITLE
Fix auto trades toggling with live mode

### DIFF
--- a/src/spectr/views/portfolio_screen.py
+++ b/src/spectr/views/portfolio_screen.py
@@ -367,6 +367,12 @@ class PortfolioScreen(Screen):
             self.equity_view.reset()
             await self._reload_account_data()
             await self._refresh_orders()
+            # Turning live trading on/off should disable auto trading
+            if self.auto_trading_enabled:
+                self.auto_trading_enabled = False
+                self.auto_switch.value = False
+                if callable(self._set_auto_trading_cb):
+                    self._set_auto_trading_cb(False)
         elif event.switch.id == "auto-trade-switch":
             self.auto_trading_enabled = event.value
             if callable(self._set_auto_trading_cb):


### PR DESCRIPTION
## Summary
- disable auto trading whenever the Live Trading switch is toggled

## Testing
- `python -m pip list | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_6859b633d8fc832eb570c6dd8e877c9e