### PR TITLE
Add strategy code view

### DIFF
--- a/src/spectr/default.tcss
+++ b/src/spectr/default.tcss
@@ -348,3 +348,16 @@ StrategyScreen {
 #strategy-select {
     padding: 1 1;
 }
+
+#signals-table {
+    width: 100%;
+    height: 10;
+    padding: 1 0;
+}
+
+#strategy-code {
+    width: 100%;
+    height: 20;
+    padding: 1 0;
+    overflow-y: auto;
+}


### PR DESCRIPTION
## Summary
- show the detect_signals code for the selected strategy
- style the strategy signal table and code view

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685adceb10d4832e9a110ae9e0815479