### PR TITLE
Fix get_position returning None

### DIFF
--- a/src/spectr/fetch/alpaca.py
+++ b/src/spectr/fetch/alpaca.py
@@ -280,10 +280,10 @@ class AlpacaInterface(BrokerInterface):
     def get_position(self, symbol: str):
         try:
             pos = self.get_api().get_open_position(symbol.upper())
-            log.debug(f"get_position for {symbol}: {len(pos)}")
+            log.debug(f"get_position for {symbol}: {pos}")
             return pos
-        except Exception:
-            log.debug("No position")
+        except Exception as exc:
+            log.debug(f"No position for {symbol}: {exc}")
             return None
 
     # ------------------------------------------------------------------ #


### PR DESCRIPTION
## Summary
- avoid using `len()` on Alpaca position objects in `get_position`
- log the exception from Alpaca API

## Testing
- `pip install -e .`


------
https://chatgpt.com/codex/tasks/task_e_685c0f03748c832e92529c2b402cb99b