### PR TITLE
Enable streaming text-to-speech

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ PYTHONPATH=src python -m spectr.spectr --broker alpaca --data_api fmp --scale 0.
 | `--candles`         | Enable candle chart mode (default: on).                               |
 | `--voice_agent_listen` | Enable real-time voice agent listening for the wake word. |
 | `--voice_agent_wake_word` | Word that triggers the voice agent (default: spectr). |
+| `--voice-streaming` | Enable streaming text-to-speech for the voice agent. |
 
 ---------------
 

--- a/src/spectr/cli.py
+++ b/src/spectr/cli.py
@@ -58,6 +58,11 @@ def main() -> None:
     parser.add_argument(
         "--wake_word", default="spectr", help="Wake word that triggers the voice agent"
     )
+    parser.add_argument(
+        "--voice-streaming",
+        action="store_true",
+        help="Enable streaming text-to-speech for the voice agent",
+    )
     parser.add_argument("--debug", action="store_true")
     args = parser.parse_args()
 

--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -208,6 +208,7 @@ class SpectrApp(App):
             add_symbol=self.add_symbol,
             remove_symbol=self.remove_symbol,
             get_strategy_code=lambda: get_strategy_code(self.strategy_name),
+            stream_voice=getattr(args, "voice_streaming", False),
         )
         if getattr(args, "listen", False):
             self.voice_agent.start_wake_word_listener(


### PR DESCRIPTION
## Summary
- add optional streaming voice support in `VoiceAgent`
- hook up `--voice-streaming` CLI flag
- forward streaming flag to the app
- document the new option

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c9ea8b164832e9ae129b3565c3b84