### PR TITLE
Refactor strategy next logic

### DIFF
--- a/src/spectr/strategies/__init__.py
+++ b/src/spectr/strategies/__init__.py
@@ -5,6 +5,7 @@ import pkgutil
 from typing import Type
 
 import backtrader as bt
+from .trading_strategy import TradingStrategy
 
 __all__ = ["load_strategy", "list_strategies", "get_strategy_code"]
 
@@ -24,7 +25,10 @@ def list_strategies() -> dict[str, Type[bt.Strategy]]:
             )
             continue
         for name, obj in inspect.getmembers(module, inspect.isclass):
-            if issubclass(obj, bt.Strategy) and obj is not bt.Strategy:
+            if (
+                issubclass(obj, bt.Strategy)
+                and obj not in (bt.Strategy, TradingStrategy)
+            ):
                 strategies[name] = obj
     return strategies
 

--- a/src/spectr/strategies/__init__.py
+++ b/src/spectr/strategies/__init__.py
@@ -15,6 +15,8 @@ def list_strategies() -> dict[str, Type[bt.Strategy]]:
     strategies: dict[str, Type[bt.Strategy]] = {}
     package = __name__
     for _, mod_name, _ in pkgutil.iter_modules(__path__):
+        if mod_name == "trading_strategy":
+            continue
         try:
             module = importlib.import_module(f"{package}.{mod_name}")
         except Exception as exc:  # pragma: no cover - import failures

--- a/src/spectr/strategies/awesome_oscillator.py
+++ b/src/spectr/strategies/awesome_oscillator.py
@@ -2,12 +2,12 @@ import logging
 from typing import Optional
 
 import pandas as pd
-import backtrader as bt
+from .trading_strategy import TradingStrategy
 
 log = logging.getLogger(__name__)
 
 
-class AwesomeOscillator(bt.Strategy):
+class AwesomeOscillator(TradingStrategy):
     """Awesome Oscillator strategy using two simple moving averages."""
 
     params = (
@@ -107,51 +107,14 @@ class AwesomeOscillator(bt.Strategy):
             }
         return None
 
-    # ----- Backtesting -----
-    def next(self) -> None:
-        N = max(self.p.fast_period, self.p.slow_period) + 5
-        data = {
-            "close": [self.datas[0].close[-i] for i in reversed(range(N))],
-            "open": [self.datas[0].open[-i] for i in reversed(range(N))],
-            "high": [self.datas[0].high[-i] for i in reversed(range(N))],
-            "low": [self.datas[0].low[-i] for i in reversed(range(N))],
-            "volume": [self.datas[0].volume[-i] for i in reversed(range(N))],
+    def get_lookback(self) -> int:
+        return max(self.p.fast_period, self.p.slow_period) + 5
+
+    def get_signal_args(self) -> dict:
+        return {
+            "fast_period": self.p.fast_period,
+            "slow_period": self.p.slow_period,
+            "stop_loss_pct": self.p.stop_loss_pct,
+            "take_profit_pct": self.p.take_profit_pct,
         }
-        df = pd.DataFrame(data)
-
-        signal = self.detect_signals(
-            df,
-            self.p.symbol,
-            position=self.position,
-            fast_period=self.p.fast_period,
-            slow_period=self.p.slow_period,
-            stop_loss_pct=self.p.stop_loss_pct,
-            take_profit_pct=self.p.take_profit_pct,
-        )
-        if not signal:
-            log.debug("No signal detected, skipping this bar.")
-            return
-        else:
-            log.debug(f"Signal detected: {signal}")
-
-        if signal.get("signal") == "buy" and not self.position.get(self.symbol):
-            log.debug(f"BACKTEST: Buy signal detected: {signal['reason']}")
-            self.buy()
-            self.buy_signals.append(
-                {
-                    "type": "buy",
-                    "time": self.datas[0].datetime.datetime(0),
-                    "price": self.datas[0].close[0],
-                }
-            )
-        elif signal.get("signal") == "sell" and self.position.get(self.symbol):
-            log.debug(f"BACKTEST: Sell signal detected: {signal['reason']}")
-            self.sell()
-            self.sell_signals.append(
-                {
-                    "type": "sell",
-                    "time": self.datas[0].datetime.datetime(0),
-                    "price": self.datas[0].close[0],
-                }
-            )
 

--- a/src/spectr/strategies/custom_strategy.py
+++ b/src/spectr/strategies/custom_strategy.py
@@ -1,12 +1,12 @@
 import logging
 
 import pandas as pd
-import backtrader as bt
+from .trading_strategy import TradingStrategy
 
 log = logging.getLogger(__name__)
 
 
-class CustomStrategy(bt.Strategy):
+class CustomStrategy(TradingStrategy):
     """Simple strategy used for both live signals and backtesting."""
 
     params = (
@@ -64,49 +64,15 @@ class CustomStrategy(bt.Strategy):
             }
         return None
 
-    # ----- Backtesting -----
-    def next(self):
-        # Build a DataFrame from the most recent N bars
-        N = 200  # Enough for MACD and BB
-        data = {
-            'close': [self.datas[0].close[-i] for i in reversed(range(N))],
-            'open': [self.datas[0].open[-i] for i in reversed(range(N))],
-            'high': [self.datas[0].high[-i] for i in reversed(range(N))],
-            'low': [self.datas[0].low[-i] for i in reversed(range(N))],
-            'volume': [self.datas[0].volume[-i] for i in reversed(range(N))],
+    def get_lookback(self) -> int:
+        return 200
+
+    def get_signal_args(self) -> dict:
+        return {
+            "stop_loss_pct": self.p.stop_loss_pct,
+            "take_profit_pct": self.p.take_profit_pct,
+            "bb_period": self.p.bb_period,
+            "bb_dev": self.p.bb_dev,
+            "macd_thresh": self.p.macd_thresh,
         }
-        df = pd.DataFrame(data)
-
-        signal = self.detect_signals(
-            df,
-            self.p.symbol,
-            position=self.position,
-            stop_loss_pct=self.p.stop_loss_pct,
-            take_profit_pct=self.p.take_profit_pct,
-            bb_period=self.p.bb_period,
-            bb_dev=self.p.bb_dev,
-            macd_thresh=self.p.macd_thresh,
-        )
-        if not signal:
-            log.debug("No signal detected, skipping this bar.")
-            return
-        else:
-            log.debug(f"Signal detected: {signal}")
-
-        if signal.get('signal') == 'buy' and not self.position.get(self.symbol):
-            log.debug(f"BACKTEST: Buy signal detected: {signal['reason']}")
-            self.buy()
-            self.buy_signals.append({
-                'type': 'buy',
-                'time': self.datas[0].datetime.datetime(0),
-                'price': self.datas[0].close[0],
-            })
-        elif signal.get('signal') == 'sell' and self.position.get(self.symbol):
-            log.debug(f"BACKTEST: Sell signal detected: {signal['reason']}")
-            self.sell()
-            self.sell_signals.append({
-                'type': 'sell',
-                'time': self.datas[0].datetime.datetime(0),
-                'price': self.datas[0].close[0],
-            })
 

--- a/src/spectr/strategies/shooting_star.py
+++ b/src/spectr/strategies/shooting_star.py
@@ -2,12 +2,12 @@ import logging
 from typing import Optional
 
 import pandas as pd
-import backtrader as bt
+from .trading_strategy import TradingStrategy
 
 log = logging.getLogger(__name__)
 
 
-class ShootingStar(bt.Strategy):
+class ShootingStar(TradingStrategy):
     """Shooting Star candlestick pattern strategy."""
 
     params = (
@@ -72,28 +72,18 @@ class ShootingStar(bt.Strategy):
             }
         return None
 
-    # ----- Backtesting -----
-    def next(self) -> None:
-        N = 10
-        data = {
-            "close": [self.datas[0].close[-i] for i in reversed(range(N))],
-            "open": [self.datas[0].open[-i] for i in reversed(range(N))],
-            "high": [self.datas[0].high[-i] for i in reversed(range(N))],
-            "low": [self.datas[0].low[-i] for i in reversed(range(N))],
-            "volume": [self.datas[0].volume[-i] for i in reversed(range(N))],
+    def get_lookback(self) -> int:
+        return 10
+
+    def get_signal_args(self) -> dict:
+        return {
+            "lower_bound": self.p.lower_bound,
+            "body_size": self.p.body_size,
+            "stop_threshold": self.p.stop_threshold,
+            "holding_period": self.p.holding_period,
         }
-        df = pd.DataFrame(data)
 
-        signal = self.detect_signals(
-            df,
-            self.p.symbol,
-            position=self.position,
-            lower_bound=self.p.lower_bound,
-            body_size=self.p.body_size,
-            stop_threshold=self.p.stop_threshold,
-            holding_period=self.p.holding_period,
-        )
-
+    def handle_signal(self, signal: Optional[dict]) -> None:
         if signal:
             log.debug(f"Signal detected: {signal}")
         else:

--- a/src/spectr/strategies/trading_strategy.py
+++ b/src/spectr/strategies/trading_strategy.py
@@ -1,0 +1,65 @@
+import logging
+from typing import Optional, Any
+
+import pandas as pd
+import backtrader as bt
+
+log = logging.getLogger(__name__)
+
+
+class TradingStrategy(bt.Strategy):
+    """Common ``next`` implementation shared by many strategies."""
+
+    params = (("symbol", ""),)
+
+    def get_lookback(self) -> int:
+        """Return how many bars to include in the DataFrame."""
+        return 200
+
+    def get_signal_args(self) -> dict[str, Any]:
+        """Return keyword arguments to pass to :meth:`detect_signals`."""
+        return {}
+
+    def build_dataframe(self, lookback: int) -> pd.DataFrame:
+        data = {
+            "close": [self.datas[0].close[-i] for i in reversed(range(lookback))],
+            "open": [self.datas[0].open[-i] for i in reversed(range(lookback))],
+            "high": [self.datas[0].high[-i] for i in reversed(range(lookback))],
+            "low": [self.datas[0].low[-i] for i in reversed(range(lookback))],
+            "volume": [self.datas[0].volume[-i] for i in reversed(range(lookback))],
+        }
+        return pd.DataFrame(data)
+
+    def handle_signal(self, signal: Optional[dict]) -> None:
+        if not signal:
+            log.debug("No signal detected, skipping this bar.")
+            return
+
+        log.debug(f"Signal detected: {signal}")
+
+        if signal.get("signal") == "buy" and not self.position.get(self.p.symbol):
+            self.buy()
+            self.buy_signals.append(
+                {
+                    "type": "buy",
+                    "time": self.datas[0].datetime.datetime(0),
+                    "price": self.datas[0].close[0],
+                }
+            )
+        elif signal.get("signal") == "sell" and self.position.get(self.p.symbol):
+            self.sell()
+            self.sell_signals.append(
+                {
+                    "type": "sell",
+                    "time": self.datas[0].datetime.datetime(0),
+                    "price": self.datas[0].close[0],
+                }
+            )
+
+    def next(self) -> None:
+        lookback = self.get_lookback()
+        df = self.build_dataframe(lookback)
+        signal = self.detect_signals(
+            df, self.p.symbol, position=self.position, **self.get_signal_args()
+        )
+        self.handle_signal(signal)


### PR DESCRIPTION
## Summary
- add TradingStrategy base class with shared `next` implementation
- make strategy modules inherit from TradingStrategy
- exclude TradingStrategy from strategy discovery

## Testing
- `python -m compileall -q src/spectr/strategies`

------
https://chatgpt.com/codex/tasks/task_e_685ce6476b54832e97efe3db0e33daeb