### PR TITLE
Fix missing args for backtest data fetch

### DIFF
--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -1018,6 +1018,9 @@ class SpectrApp(App):
             df, _ = await asyncio.to_thread(
                 get_historical_data,
                 DATA_API,
+                self.config.bb_period,
+                self.config.bb_dev,
+                self.config.macd_thresh,
                 symbol,
                 from_date=form["from"],
                 to_date=form["to"],


### PR DESCRIPTION
## Summary
- include Bollinger Band and MACD config params when calling `get_historical_data`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685de9cac3fc832eaeec035980056299