### PR TITLE
Silence pygame deprecation warnings

### DIFF
--- a/src/spectr/agent.py
+++ b/src/spectr/agent.py
@@ -8,6 +8,14 @@ import time
 from typing import Callable, Optional
 
 from openai import OpenAI
+import warnings
+os.environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "1"
+warnings.filterwarnings(
+    "ignore",
+    message="pkg_resources is deprecated as an API.*",
+    category=UserWarning,
+    module="pygame.pkgdata",
+)
 import pygame
 try:  # optional voice dependencies
     import sounddevice as sd

--- a/src/spectr/utils.py
+++ b/src/spectr/utils.py
@@ -7,10 +7,17 @@ from tzlocal import get_localzone
 
 import pandas as pd
 import threading
+import warnings
 
 from .strategies import metrics
 
 os.environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "1"
+warnings.filterwarnings(
+    "ignore",
+    message="pkg_resources is deprecated as an API.*",
+    category=UserWarning,
+    module="pygame.pkgdata",
+)
 import pygame
 
 from .fetch import data_interface


### PR DESCRIPTION
## Summary
- suppress `pkg_resources` deprecation notice coming from pygame

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6861d01a0300832e850f75ccfe658db8