### PR TITLE
Fix position check for ShootingStar strategy

### DIFF
--- a/src/spectr/strategies/awesome_oscillator.py
+++ b/src/spectr/strategies/awesome_oscillator.py
@@ -57,7 +57,7 @@ class AwesomeOscillator(TradingStrategy):
 
         in_position = False
         if position is not None:
-            qty = getattr(position, "qty", 0)
+            qty = getattr(position, "qty", getattr(position, "size", 0))
             try:
                 in_position = float(qty) != 0
             except Exception:

--- a/src/spectr/strategies/custom_strategy.py
+++ b/src/spectr/strategies/custom_strategy.py
@@ -40,7 +40,15 @@ class CustomStrategy(TradingStrategy):
         above_bb = curr.get("close", 0) > curr.get("bb_upper", 0)
         below_bb = curr.get("close", 0) < curr.get("bb_mid", 0)
 
-        if position is None or float(getattr(position, "qty", 0)) == 0:
+        qty = 0
+        if position is not None:
+            qty = getattr(position, "qty", getattr(position, "size", 0))
+            try:
+                qty = float(qty)
+            except Exception:
+                qty = 0.0
+
+        if position is None or qty == 0:
             if macd_cross == "buy":
                 signal = "buy"
                 reason = "MACD crossover"

--- a/src/spectr/strategies/dual_thrust.py
+++ b/src/spectr/strategies/dual_thrust.py
@@ -75,11 +75,13 @@ class DualThrust(TradingStrategy):
         reason = None
         price = float(curr.get("close", 0))
 
-        qty = getattr(position, "qty", 0) if position is not None else 0
-        try:
-            qty = float(qty)
-        except Exception:
-            qty = 0.0
+        qty = 0
+        if position is not None:
+            qty = getattr(position, "qty", getattr(position, "size", 0))
+            try:
+                qty = float(qty)
+            except Exception:
+                qty = 0.0
         in_pos = qty != 0
         pos_dir = 1 if qty > 0 else -1 if qty < 0 else 0
 

--- a/src/spectr/strategies/macd_oscillator.py
+++ b/src/spectr/strategies/macd_oscillator.py
@@ -58,8 +58,11 @@ class MACDOscillator(TradingStrategy):
 
         in_position = False
         if position is not None:
-            qty = getattr(position, "qty", 0)
-            in_position = float(qty) != 0
+            qty = getattr(position, "qty", getattr(position, "size", 0))
+            try:
+                in_position = float(qty) != 0
+            except Exception:
+                in_position = bool(qty)
 
         if not in_position:
             if curr_osc > 0 and prev_osc <= 0:

--- a/src/spectr/strategies/trading_strategy.py
+++ b/src/spectr/strategies/trading_strategy.py
@@ -37,7 +37,7 @@ class TradingStrategy(bt.Strategy):
 
         log.debug(f"Signal detected: {signal}")
 
-        if signal.get("signal") == "buy" and not self.position.get(self.p.symbol):
+        if signal.get("signal") == "buy" and not self.position:
             self.buy()
             self.buy_signals.append(
                 {
@@ -46,7 +46,7 @@ class TradingStrategy(bt.Strategy):
                     "price": self.datas[0].close[0],
                 }
             )
-        elif signal.get("signal") == "sell" and self.position.get(self.p.symbol):
+        elif signal.get("signal") == "sell" and self.position:
             self.sell()
             self.sell_signals.append(
                 {


### PR DESCRIPTION
## Summary
- check current position for the strategy's symbol when selling or closing shorts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861e93c2494832e97f925dc08771b23