### PR TITLE
Fix sub-penny limit prices

### DIFF
--- a/src/spectr/broker_tools.py
+++ b/src/spectr/broker_tools.py
@@ -29,6 +29,7 @@ def prepare_order_details(symbol: str, side: OrderSide, data_api) -> tuple[Order
             )
             if limit_price:
                 limit_price *= 1.003
+                limit_price = round(limit_price, 2)
         else:
             limit_price = (
                 quote.get("bid")
@@ -38,6 +39,7 @@ def prepare_order_details(symbol: str, side: OrderSide, data_api) -> tuple[Order
             )
             if limit_price:
                 limit_price *= 0.997
+                limit_price = round(limit_price, 2)
 
     log.debug(
         f"Order details for {symbol}: type={order_type}, limit_price={limit_price}"

--- a/tests/test_broker_tools.py
+++ b/tests/test_broker_tools.py
@@ -51,9 +51,11 @@ def test_prepare_order_details_equity(monkeypatch, side, is_open, expected_type,
     if expected_price_key is None:
         assert limit_price is None
     elif expected_price_key == "ask":
-        assert limit_price == pytest.approx(quote["ask"] * 1.003)
+        expected = round(quote["ask"] * 1.003, 2)
+        assert limit_price == expected
     else:
-        assert limit_price == pytest.approx(quote["bid"] * 0.997)
+        expected = round(quote["bid"] * 0.997, 2)
+        assert limit_price == expected
 
 
 @pytest.mark.parametrize("side,is_open", [(OrderSide.BUY, True), (OrderSide.SELL, True), (OrderSide.BUY, False), (OrderSide.SELL, False)])
@@ -95,10 +97,10 @@ def test_submit_order_equity(monkeypatch, side, is_open, expected_type):
         assert broker.submitted["limit_price"] is None
     else:
         if side == OrderSide.BUY:
-            exp = quote["ask"] * 1.003
+            exp = round(quote["ask"] * 1.003, 2)
         else:
-            exp = quote["bid"] * 0.997
-        assert broker.submitted["limit_price"] == pytest.approx(exp)
+            exp = round(quote["bid"] * 0.997, 2)
+        assert broker.submitted["limit_price"] == exp
 
 
 @pytest.mark.parametrize("is_open", [True, False])


### PR DESCRIPTION
## Summary
- round limit prices for equities to two decimals
- update tests for new rounding behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864cee38b40832ea5e898c8e6d014da