### PR TITLE
Use broker quotes for afterhours limit pricing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
   "ta>=0.11",
   "openai>=1.0",
   "python-dotenv>=1.0",
+  "robin_stocks>=2.1",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ openai
 soundfile
 sounddevice
 black
+robin_stocks>=2.1

--- a/src/spectr/fetch/broker_interface.py
+++ b/src/spectr/fetch/broker_interface.py
@@ -7,16 +7,19 @@ import pandas as pd
 class OrderType(Enum):
     MARKET = 1
     LIMIT = 2
-    #STOP_LIMIT = 3  # Not implemented yet
-    #TRAILING_STOP = 4  # Not implemented yet
+    # STOP_LIMIT = 3  # Not implemented yet
+    # TRAILING_STOP = 4  # Not implemented yet
+
 
 class OrderSide(Enum):
     BUY = 1
     SELL = 2
 
+
 class OrderSubmission:
     symbol: str
     side: OrderSide
+
 
 class BrokerInterface(ABC):
 
@@ -28,7 +31,7 @@ class BrokerInterface(ABC):
 
     @abstractmethod
     def get_balance(self):
-        """ Return cash and portfolio metrics for the current amount. """
+        """Return cash and portfolio metrics for the current amount."""
         pass
 
     @abstractmethod
@@ -72,6 +75,11 @@ class BrokerInterface(ABC):
         pass
 
     @abstractmethod
+    def fetch_quote(self, symbol: str) -> dict:
+        """Fetch a real-time quote for *symbol* from the broker."""
+        pass
+
+    @abstractmethod
     def submit_order(
         self,
         symbol: str,
@@ -88,4 +96,3 @@ class BrokerInterface(ABC):
     def cancel_order(self, order_id: str) -> bool:
         """Cancel an open order by its unique id. Returns True on success."""
         pass
-    

--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -325,7 +325,6 @@ class SpectrApp(App):
                 curr_price,
                 self.trade_amount,
                 self.auto_trading_enabled,
-                data_api=DATA_API,
                 voice_agent=self.voice_agent,
                 buy_sound_path=BUY_SOUND_PATH,
                 sell_sound_path=SELL_SOUND_PATH,
@@ -494,7 +493,6 @@ class SpectrApp(App):
                             price,
                             self.trade_amount,
                             self.auto_trading_enabled,
-                            data_api=DATA_API,
                             voice_agent=self.voice_agent,
                             buy_sound_path=BUY_SOUND_PATH,
                             sell_sound_path=SELL_SOUND_PATH,
@@ -717,7 +715,7 @@ class SpectrApp(App):
         if self._is_splash_active():
             return
         order_type, limit_price = broker_tools.prepare_order_details(
-            symbol, side, DATA_API
+            symbol, side, BROKER_API
         )
         self.push_screen(
             OrderDialog(
@@ -725,7 +723,7 @@ class SpectrApp(App):
                 symbol=symbol,
                 pos_pct=pos_pct,
                 get_pos_cb=BROKER_API.get_position,
-                get_price_cb=DATA_API.fetch_quote,
+                get_price_cb=BROKER_API.fetch_quote,
                 trade_amount=self.trade_amount if side == OrderSide.BUY else 0.0,
                 reason=reason,
                 default_order_type=order_type,


### PR DESCRIPTION
## Summary
- fetch quotes directly from the broker
- use broker quotes when preparing limit orders
- update Alpaca interface with `fetch_quote`
- wire Spectr to use broker quotes
- adjust tests and dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864d21ba754832e8d053bb0179267a7