### PR TITLE
Use indicator specs for analysis

### DIFF
--- a/src/spectr/backtest.py
+++ b/src/spectr/backtest.py
@@ -65,13 +65,10 @@ def run_backtest(
         )
 
     # Ensure indicators are present
-    if "macd" not in df.columns or "bb_mid" not in df.columns:
-        df = metrics.analyze_indicators(
-            df,
-            config.bb_period,
-            config.bb_dev,
-            config.macd_thresh,
-        )
+    df = metrics.analyze_indicators(
+        df,
+        strategy_class.get_indicators(),
+    )
 
     cerebro = bt.Cerebro()
     # Dynamically map ``config`` attributes onto the strategy parameters.  This

--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -288,9 +288,7 @@ class SpectrApp(App):
         log.debug("Analyzing indicators")
         df = metrics.analyze_indicators(
             df,
-            self.config.bb_period,
-            self.config.bb_dev,
-            self.config.macd_thresh,
+            self.strategy_class.get_indicators(),
         )
         df["trade"] = None
         df["signal"] = None

--- a/src/spectr/strategies/custom_strategy.py
+++ b/src/spectr/strategies/custom_strategy.py
@@ -52,7 +52,10 @@ class CustomStrategy(TradingStrategy):
                 df.iloc[-1].get("bb_upper") is None
                 or df.iloc[-1].get("bb_upper").isnan()
             ):
-                df = metrics.analyze_indicators(df, bb_period, bb_dev, macd_thresh)
+                df = metrics.analyze_indicators(
+                    df,
+                    CustomStrategy.get_indicators(),
+                )
 
         macd_cross = curr.get("macd_crossover")
         above_bb = curr.get("close", 0) > curr.get("bb_upper", 0)

--- a/src/spectr/strategies/metrics.py
+++ b/src/spectr/strategies/metrics.py
@@ -4,38 +4,63 @@ import ta
 from ta.trend import MACD
 from ta.volatility import BollingerBands
 
+from .trading_strategy import IndicatorSpec
 
-def analyze_indicators(df, bb_period, bb_dev, macd_thresh):
+
+def analyze_indicators(
+    df: pd.DataFrame, indicators: list[IndicatorSpec]
+) -> pd.DataFrame:
+    """Calculate and append indicators defined by ``indicators``."""
     df = df.copy()
 
-    if len(df.index) > 26:
-        macd = MACD(close=df['close'])
-        df['macd'] = macd.macd()
-        df['macd_signal'] = macd.macd_signal()
-        df['macd_close'] = abs(df['macd'] - df['macd_signal']) < macd_thresh
-        df['macd_angle'] = macd_angle(df['close'], 12, 26, 9)
+    for spec in indicators:
+        name = spec.name.lower()
+        params = spec.params or {}
 
-        df['macd_crossover'] = None
-        crossover = (df['macd'] > df['macd_signal']) & (df['macd'].shift(1) <= df['macd_signal'].shift(1))
-        crossunder = (df['macd'] < df['macd_signal']) & (df['macd'].shift(1) >= df['macd_signal'].shift(1))
-        df.loc[crossover, 'macd_crossover'] = 'buy'
-        df.loc[crossunder, 'macd_crossover'] = 'sell'
+        if name == "macd" and len(df.index) > 2:
+            fast = params.get("window_fast", 12)
+            slow = params.get("window_slow", 26)
+            thresh = params.get("threshold", 0.0)
+            macd = MACD(close=df["close"], window_fast=fast, window_slow=slow)
+            df["macd"] = macd.macd()
+            df["macd_signal"] = macd.macd_signal()
+            df["macd_close"] = (df["macd"] - df["macd_signal"]).abs() < thresh
+            df["macd_angle"] = macd_angle(df["close"], fast, slow, 9)
 
-    if len(df.index) > bb_period:
-        bb = BollingerBands(close=df['close'], window=bb_period, window_dev=bb_dev, fillna=False)
-        df['bb_upper'] = bb.bollinger_hband()
-        df['bb_lower'] = bb.bollinger_lband()
-        df['bb_angle'] = bollinger_band_angle(df['close'], period=5)
-        df['bb_mid'] = (df['bb_upper'] + df['bb_lower']) / 2
+            df["macd_crossover"] = None
+            crossover = (df["macd"] > df["macd_signal"]) & (
+                df["macd"].shift(1) <= df["macd_signal"].shift(1)
+            )
+            crossunder = (df["macd"] < df["macd_signal"]) & (
+                df["macd"].shift(1) >= df["macd_signal"].shift(1)
+            )
+            df.loc[crossover, "macd_crossover"] = "buy"
+            df.loc[crossunder, "macd_crossover"] = "sell"
 
-    # ---- VWAP ----------------------------------------------------------
-    # Needs both 'close' (or 'typical price') and 'volume'
-    if {'close', 'volume'}.issubset(df.columns):
-        pv = df['close'] * df['volume']  # price × volume
-        vwap = pv.cumsum() / df['volume'].cumsum()
-        df['vwap'] = vwap
+        elif name == "bollingerbands" and len(df.index) > params.get("window", 20):
+            window = params.get("window", 20)
+            window_dev = params.get("window_dev", 2.0)
+            bb = BollingerBands(
+                close=df["close"], window=window, window_dev=window_dev, fillna=False
+            )
+            df["bb_upper"] = bb.bollinger_hband()
+            df["bb_lower"] = bb.bollinger_lband()
+            df["bb_angle"] = bollinger_band_angle(df["close"], period=5)
+            df["bb_mid"] = (df["bb_upper"] + df["bb_lower"]) / 2
 
-    print(f"Analyzed indicators: {df}")
+        elif name == "vwap" and {"close", "volume"}.issubset(df.columns):
+            pv = df["close"] * df["volume"]
+            df["vwap"] = pv.cumsum() / df["volume"].cumsum()
+
+        elif name == "sma":
+            window = params.get("window", 20)
+            col_type = params.get("type")
+            if col_type:
+                col = f"ma_{col_type}"
+            else:
+                col = f"sma_{window}"
+            df[col] = df["close"].rolling(window=window, min_periods=1).mean()
+
     return df
 
 
@@ -83,7 +108,9 @@ def macd_angle(close_series, fast=12, slow=26, signal=9):
     if len(close_series) < slow + signal + 2:
         return None  # not enough data
 
-    macd_indicator = ta.trend.MACD(close=close_series, window_slow=slow, window_fast=fast, window_sign=signal)
+    macd_indicator = ta.trend.MACD(
+        close=close_series, window_slow=slow, window_fast=fast, window_sign=signal
+    )
     macd_series = macd_indicator.macd().dropna()
 
     if len(macd_series) < 2:

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -6,6 +6,7 @@ from spectr.strategies.macd_oscillator import MACDOscillator
 from spectr.strategies.awesome_oscillator import AwesomeOscillator
 from spectr.strategies.dual_thrust import DualThrust
 from spectr.strategies.trading_strategy import IndicatorSpec
+from spectr.strategies import metrics
 
 
 def _stub_analyze(df: pd.DataFrame, *args, **kwargs) -> pd.DataFrame:
@@ -245,3 +246,21 @@ def test_indicator_specs():
 
     dt_inds = DualThrust.get_indicators()
     assert dt_inds and dt_inds[0].name == "DualThrustRange"
+
+
+def test_analyze_indicators_from_specs():
+    idx = pd.date_range("2021-01-01", periods=3, freq="D")
+    df = pd.DataFrame(
+        {
+            "open": [1, 2, 3],
+            "high": [1, 2, 3],
+            "low": [1, 2, 3],
+            "close": [1, 2, 3],
+            "volume": [1, 1, 1],
+        },
+        index=idx,
+    )
+    specs = [IndicatorSpec(name="VWAP", params={})]
+    out = metrics.analyze_indicators(df, specs)
+    assert "vwap" in out.columns
+    assert "macd" not in out.columns


### PR DESCRIPTION
## Summary
- compute indicators based on strategy `IndicatorSpec`
- handle indicator specs in backtesting, utils and UI
- test `metrics.analyze_indicators` using specs

## Testing
- `black src/spectr/strategies/metrics.py src/spectr/spectr.py src/spectr/strategies/custom_strategy.py src/spectr/backtest.py src/spectr/utils.py tests/test_strategies.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6865f050eb7c832e890f0fa23a9539b3