### PR TITLE
Enable strategy-driven indicators

### DIFF
--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -938,7 +938,8 @@ class SpectrApp(App):
         df = self.df_cache.get(symbol)
         if df is not None and not self.is_backtest:
             self.symbol_view = self.query_one("#symbol-view", SymbolView)
-            self.symbol_view.load_df(symbol, df, self.args)
+            indicators = self.strategy_class.get_indicators()
+            self.symbol_view.load_df(symbol, df, self.args, indicators)
 
         self.update_status_bar()
         if self.query("#splash") and df is not None and not df.empty:
@@ -1147,6 +1148,7 @@ class SpectrApp(App):
                 BacktestResultScreen(
                     df,
                     self.args,
+                    indicators=self.strategy_class.get_indicators(),
                     symbol=symbol,
                     start_date=form["from"],
                     end_date=form["to"],

--- a/src/spectr/views/backtest_result_screen.py
+++ b/src/spectr/views/backtest_result_screen.py
@@ -17,6 +17,7 @@ class BacktestResultScreen(Screen):
         df,
         args,
         *,
+        indicators=None,
         symbol: str,
         start_date: str,
         end_date: str,
@@ -26,7 +27,9 @@ class BacktestResultScreen(Screen):
         num_sells: int,
     ) -> None:
         super().__init__()
-        self._graph = GraphView(df=df, args=args, id="backtest-graph")
+        self._graph = GraphView(
+            df=df, args=args, indicators=indicators, id="backtest-graph"
+        )
         self._graph.is_backtest = True
         self.report = Static(id="backtest-report")
         self.symbol = symbol
@@ -55,4 +58,3 @@ class BacktestResultScreen(Screen):
             f"Buys: {self.num_buys}\n"
             f"Sells: {self.num_sells}"
         )
-

--- a/src/spectr/views/graph_view.py
+++ b/src/spectr/views/graph_view.py
@@ -13,18 +13,21 @@ import numpy
 
 log = logging.getLogger(__name__)
 
+
 class GraphView(Static):
     symbol: reactive[str] = reactive("")
     quote: reactive[dict] = reactive(None)
     is_backtest: reactive[bool] = reactive(False)
+    indicators: reactive[list] = reactive([])
 
     def update_symbol(self, value: str):
         self.symbol = value
 
-    def __init__(self, df=None, args=None, **kwargs):
+    def __init__(self, df=None, args=None, indicators=None, **kwargs):
         super().__init__(**kwargs)
         self.df = df
         self.args = args
+        self.indicators = indicators or []
 
     def on_mount(self):
         self.set_interval(0.5, self.refresh)  # Force refresh loop, optional
@@ -44,10 +47,12 @@ class GraphView(Static):
     def watch_is_backtest(self, old, new):
         self.refresh()
 
-    def load_df(self, df, args):
+    def load_df(self, df, args, indicators=None):
         """Store the DataFrame and redraw on next refresh."""
         self.df = df
         self.args = args
+        if indicators is not None:
+            self.indicators = indicators
         self.refresh()
 
     def render(self):
@@ -71,93 +76,161 @@ class GraphView(Static):
         # Extract time labels and prices
 
         dates = df.index.tz_convert("UTC").strftime("%Y-%m-%d %H:%M:%S")
-        #ohlc_data = list(zip(df['open'], df['high'], df['low'], df['close']))
+        # ohlc_data = list(zip(df['open'], df['high'], df['low'], df['close']))
 
         # Rename the 'open' column to 'Open'
-        df = df.rename(columns={'low': 'Low', 'high': 'High', 'open': 'Open', 'close': 'Close', 'volume': 'Volume', 'vwap': 'VWAP'})
+        df = df.rename(
+            columns={
+                "low": "Low",
+                "high": "High",
+                "open": "Open",
+                "close": "Close",
+                "volume": "Volume",
+                "vwap": "VWAP",
+            }
+        )
 
         # Clear and configure plotext
         plt.clf()
-        plt.canvas_color('default')
-        plt.axes_color('default')
-        plt.ticks_color('default')
+        plt.canvas_color("default")
+        plt.axes_color("default")
+        plt.ticks_color("default")
         plt.grid(False)
-        plt.date_form(input_form="Y-m-d H:M:S", output_form="H:M:S")  # for times like 13:45:12
+        plt.date_form(
+            input_form="Y-m-d H:M:S", output_form="H:M:S"
+        )  # for times like 13:45:12
+
+        inds = {spec.name.lower() for spec in self.indicators}
 
         # Plot Bollinger Bands
-        if "bb_upper" in df.columns and not df["bb_upper"].isna().all():
-            plt.plot(dates, df['bb_upper'], color="red", label="BB Upper", yside="right", marker='dot')
-        if "bb_mid" in df.columns and not df["bb_mid"].isna().all():
-            plt.plot(dates, df['bb_mid'], color="blue", label="BB Mid", yside="right", marker='-')
-        if "bb_lower" in df.columns and not df["bb_lower"].isna().all():
-            plt.plot(dates, df['bb_lower'], color="green", label="BB Lower", yside="right", marker='dot')
+        if "bollingerbands" in inds:
+            if "bb_upper" in df.columns and not df["bb_upper"].isna().all():
+                plt.plot(
+                    dates,
+                    df["bb_upper"],
+                    color="red",
+                    label="BB Upper",
+                    yside="right",
+                    marker="dot",
+                )
+            if "bb_mid" in df.columns and not df["bb_mid"].isna().all():
+                plt.plot(
+                    dates,
+                    df["bb_mid"],
+                    color="blue",
+                    label="BB Mid",
+                    yside="right",
+                    marker="-",
+                )
+            if "bb_lower" in df.columns and not df["bb_lower"].isna().all():
+                plt.plot(
+                    dates,
+                    df["bb_lower"],
+                    color="green",
+                    label="BB Lower",
+                    yside="right",
+                    marker="dot",
+                )
 
-        if "VWAP" in df.columns:
-            plt.plot(dates, df['VWAP'], yside='right', marker='hd', color="orange", label="VWAP")
+        if "vwap" in inds and "VWAP" in df.columns:
+            plt.plot(
+                dates,
+                df["VWAP"],
+                yside="right",
+                marker="hd",
+                color="orange",
+                label="VWAP",
+            )
+
+        if "sma" in inds:
+            for spec in self.indicators:
+                if spec.name.lower() != "sma":
+                    continue
+                col_type = spec.params.get("type")
+                if col_type:
+                    col = f"ma_{col_type}"
+                else:
+                    window = spec.params.get("window", 20)
+                    col = f"sma_{window}"
+                if col in df.columns:
+                    plt.plot(
+                        dates, df[col], yside="right", label=col.upper(), marker="dot"
+                    )
 
         if self.args.candles:
             # Add candlesticks
-            plt.candlestick(dates, df[['Open', 'Close', 'High', 'Low']], yside='right')
+            plt.candlestick(dates, df[["Open", "Close", "High", "Low"]], yside="right")
         else:
-            plt.plot(dates, df['Close'], yside='right', marker='hd', color='green')
+            plt.plot(dates, df["Close"], yside="right", marker="hd", color="green")
 
         # -------- BUY / SELL MARKERS ---------
         last_buy_y = last_buy_x = None
         last_sell_y = last_sell_x = None
-        if 'buy_signals' in df.columns:
-            buy_mask = df['buy_signals'].astype(bool)
+        if "buy_signals" in df.columns:
+            buy_mask = df["buy_signals"].astype(bool)
 
             # Plot green ▲ for buys
             if buy_mask.any():
                 buy_x = np.array(dates)[buy_mask]
-                buy_y = df.loc[buy_mask, 'Close']
-                plt.scatter(buy_x, buy_y,
-                            marker='O', color='green',
-                            label = 'Buy', yside = 'right')
+                buy_y = df.loc[buy_mask, "Close"]
+                plt.scatter(
+                    buy_x, buy_y, marker="O", color="green", label="Buy", yside="right"
+                )
                 last_buy_x, last_buy_y = buy_x[-1], float(buy_y.iloc[-1])
 
-        if 'sell_signals' in df.columns:
-            sell_mask = df['sell_signals'].astype(bool)
+        if "sell_signals" in df.columns:
+            sell_mask = df["sell_signals"].astype(bool)
 
             # Plot red ▼ for sells
             if sell_mask.any():
                 sell_x = np.array(dates)[sell_mask]
-                sell_y = df.loc[sell_mask, 'Close']
-                plt.scatter(sell_x, sell_y,
-                             marker = 'X', color = 'red',
-                             label = 'Sell', yside = 'right')
+                sell_y = df.loc[sell_mask, "Close"]
+                plt.scatter(
+                    sell_x, sell_y, marker="X", color="red", label="Sell", yside="right"
+                )
                 # remember the LAST sell to label on the right
                 last_sell_x, last_sell_y = sell_x[-1], float(sell_y.iloc[-1])
 
         # -------- PRICE LABELS ON THE RIGHT EDGE -------------------------
 
         if last_buy_y is not None:
-            plt.text(f"${last_buy_y:.2f}",
-                                  last_buy_x,
-                                  last_buy_y,
-                                  color = "green",
-            yside = "right")
+            plt.text(
+                f"${last_buy_y:.2f}",
+                last_buy_x,
+                last_buy_y,
+                color="green",
+                yside="right",
+            )
 
         if last_sell_y is not None:
-            plt.text(f"${last_sell_y:.2f}",
-                                last_sell_x,
-                                last_sell_y,
-                                color = "red",
-            yside = "right")
+            plt.text(
+                f"${last_sell_y:.2f}",
+                last_sell_x,
+                last_sell_y,
+                color="red",
+                yside="right",
+            )
 
         last_x = dates[-1]
-        last_y = df['Close'].iloc[-1]
+        last_y = df["Close"].iloc[-1]
         price_label = f"${last_y:.2f}"
 
-        plt.text(price_label, last_x, last_y + 0.5, color="green", style='#price_label', yside='right')
+        plt.text(
+            price_label,
+            last_x,
+            last_y + 0.5,
+            color="green",
+            style="#price_label",
+            yside="right",
+        )
         plt.title(f"{self.symbol} - {price_label}")
 
         # Align the latest price_label in a center vertically
-        current_price = df['Close'].iloc[-1]
+        current_price = df["Close"].iloc[-1]
         plt.ylim(current_price * 0.90, current_price * 1.1)
 
         width = max(self.size.width, 20)  # leave some margin
         height = max(self.size.height, 10)  # reasonable min height
-        plt.plotsize(width-3, height)
+        plt.plotsize(width - 3, height)
 
         return Text.from_ansi(plt.build())

--- a/tests/test_symbol_view.py
+++ b/tests/test_symbol_view.py
@@ -1,0 +1,50 @@
+import pandas as pd
+from types import SimpleNamespace
+
+from spectr.views.symbol_view import SymbolView
+from spectr.views.graph_view import GraphView
+from spectr.views.macd_view import MACDView
+from spectr.views.volume_view import VolumeView
+from spectr.strategies.trading_strategy import IndicatorSpec
+
+
+def _dummy_df():
+    idx = pd.date_range("2024-01-01", periods=2, freq="min")
+    return pd.DataFrame(
+        {
+            "open": [1, 1],
+            "high": [1, 1],
+            "low": [1, 1],
+            "close": [1, 1],
+            "volume": [1, 1],
+        },
+        index=idx,
+    )
+
+
+def _dummy_args():
+    return SimpleNamespace(scale=1, candles=True)
+
+
+def test_symbol_view_macd_visibility():
+    sv = SymbolView()
+    sv.graph = GraphView()
+    sv.macd = MACDView()
+    sv.volume = VolumeView()
+    df = _dummy_df()
+    specs = [IndicatorSpec(name="MACD", params={})]
+    sv.load_df("TEST", df, _dummy_args(), specs)
+    assert sv.macd.display is True
+    assert sv.graph.indicators == specs
+
+
+def test_symbol_view_without_macd():
+    sv = SymbolView()
+    sv.graph = GraphView()
+    sv.macd = MACDView()
+    sv.volume = VolumeView()
+    df = _dummy_df()
+    specs = [IndicatorSpec(name="VWAP", params={})]
+    sv.load_df("TEST", df, _dummy_args(), specs)
+    assert sv.macd.display is False
+    assert sv.graph.indicators == specs


### PR DESCRIPTION
## Summary
- allow `GraphView` to accept a list of indicators and draw only those
- toggle `MACDView` visibility based on active strategy indicators
- pass strategy indicators through `SpectrApp` into `SymbolView`
- support indicator-aware backtest result screens
- test indicator handling in `SymbolView`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866060c91a8832e9e7e481b23aa6313