### PR TITLE
Use single MACD spec

### DIFF
--- a/src/spectr/strategies/macd_oscillator.py
+++ b/src/spectr/strategies/macd_oscillator.py
@@ -93,11 +93,10 @@ class MACDOscillator(TradingStrategy):
     def get_indicators(cls) -> list[IndicatorSpec]:
         return [
             IndicatorSpec(
-                name="SMA",
-                params={"window": cls.params.fast_period, "type": "fast"},
-            ),
-            IndicatorSpec(
-                name="SMA",
-                params={"window": cls.params.slow_period, "type": "slow"},
-            ),
+                name="MACD",
+                params={
+                    "window_fast": cls.params.fast_period,
+                    "window_slow": cls.params.slow_period,
+                },
+            )
         ]

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -239,7 +239,7 @@ def test_indicator_specs():
     assert any(spec.name == "MACD" for spec in CustomStrategy.get_indicators())
 
     mo_inds = MACDOscillator.get_indicators()
-    assert any(spec.params.get("type") == "fast" for spec in mo_inds)
+    assert len(mo_inds) == 1 and mo_inds[0].name == "MACD"
 
     ao_inds = AwesomeOscillator.get_indicators()
     assert len(ao_inds) == 2


### PR DESCRIPTION
## Summary
- update `MACDOscillator` to return a MACD indicator spec
- adjust tests for new indicator spec

## Testing
- `pip install pandas backtrader textual[syntax] tzlocal pygame sounddevice soundfile plotext ta openai python-dotenv robin_stocks requests numpy -q`
- `pip install -e . -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686697a96b1c832e9c0fa56af5dcfb8f