### PR TITLE
Add trade amount cache

### DIFF
--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -215,6 +215,9 @@ class SpectrApp(App):
         self._shutting_down = False
 
         self.trade_amount = 0.0
+        cached_amount = cache.load_trade_amount()
+        if cached_amount is not None:
+            self.trade_amount = cached_amount
 
         self.voice_agent = VoiceAgent(
             broker_api=BROKER_API,
@@ -981,6 +984,7 @@ class SpectrApp(App):
             self.trade_amount = float(amount)
         except ValueError:
             self.trade_amount = 0.0
+        cache.save_trade_amount(self.trade_amount)
 
     def set_strategy(self, name: str) -> None:
         """Change the active trading strategy."""

--- a/tests/test_trade_amount_cache.py
+++ b/tests/test_trade_amount_cache.py
@@ -1,0 +1,10 @@
+import json
+from spectr import cache
+
+
+def test_trade_amount_cache(tmp_path, monkeypatch):
+    path = tmp_path / "amt.json"
+    monkeypatch.setattr(cache, "TRADE_AMOUNT_FILE", path)
+    cache.save_trade_amount(123.45)
+    assert path.exists()
+    assert cache.load_trade_amount() == 123.45


### PR DESCRIPTION
## Summary
- cache trade amount in `cache.py`
- persist the value in `SpectrApp`
- add a regression test for trade amount caching

## Testing
- `black src/spectr/cache.py src/spectr/spectr.py tests/test_trade_amount_cache.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6866ab233770832e8ada50ec520d3b15