### PR TITLE
Consolidate caches into single file

### DIFF
--- a/src/spectr/cache.py
+++ b/src/spectr/cache.py
@@ -12,13 +12,82 @@ log = logging.getLogger(__name__)
 CACHE_DIR = "cache"
 CACHE_PATH_STR = ".{}.cache"
 
-SYMBOLS_CACHE_PATH = pathlib.Path.home() / ".spectr_symbols_cache.json"
-SCANNER_CACHE_FILE = pathlib.Path.home() / ".spectr_scanner_cache.json"
-GAINERS_CACHE_FILE = pathlib.Path.home() / ".spectr_gainers_cache.json"
-STRATEGY_CACHE_FILE = pathlib.Path.home() / ".spectr_strategy_cache.json"
-STRATEGY_NAME_FILE = pathlib.Path.home() / ".spectr_selected_strategy.json"
-SCANNER_NAME_FILE = pathlib.Path.home() / ".spectr_selected_scanner.json"
-TRADE_AMOUNT_FILE = pathlib.Path.home() / ".spectr_trade_amount.json"
+SYMBOLS_CACHE_PATH = pathlib.Path.home() / ".spectr_symbols_cache.json"  # legacy
+SCANNER_CACHE_FILE = pathlib.Path.home() / ".spectr_scanner_cache.json"  # legacy
+GAINERS_CACHE_FILE = pathlib.Path.home() / ".spectr_gainers_cache.json"  # legacy
+STRATEGY_CACHE_FILE = pathlib.Path.home() / ".spectr_strategy_cache.json"  # legacy
+STRATEGY_NAME_FILE = pathlib.Path.home() / ".spectr_selected_strategy.json"  # legacy
+SCANNER_NAME_FILE = pathlib.Path.home() / ".spectr_selected_scanner.json"  # legacy
+TRADE_AMOUNT_FILE = pathlib.Path.home() / ".spectr_trade_amount.json"  # legacy
+ONBOARD_FILE = pathlib.Path.home() / ".spectr_onboard.json"
+
+COMBINED_CACHE_FILE = pathlib.Path.home() / ".spectr_cache.json"
+
+
+def _load_combined(path: pathlib.Path = COMBINED_CACHE_FILE) -> dict:
+    try:
+        data = json.loads(path.read_text())
+        if isinstance(data, dict):
+            return data
+    except Exception:
+        pass
+    return {}
+
+
+def _save_combined(data: dict, path: pathlib.Path = COMBINED_CACHE_FILE) -> None:
+    try:
+        path.write_text(json.dumps(data, indent=0))
+    except Exception as exc:
+        log.error(f"combined cache write failed: {exc}")
+
+
+def _load_legacy_strategy_cache(path: pathlib.Path) -> list[dict]:
+    try:
+        rows = json.loads(path.read_text())
+    except Exception:
+        return []
+    out = []
+    for rec in rows:
+        if isinstance(rec, dict):
+            ts = rec.get("time")
+            if ts:
+                try:
+                    rec["time"] = datetime.fromisoformat(ts)
+                except Exception:
+                    rec["time"] = None
+            out.append(rec)
+    return out
+
+
+def _merge_legacy_caches(path: pathlib.Path = COMBINED_CACHE_FILE) -> dict:
+    data = _load_combined(path)
+    changed = False
+
+    def merge(key: str, fpath: pathlib.Path, loader):
+        nonlocal changed
+        if fpath.exists():
+            try:
+                data[key] = loader(fpath)
+                changed = True
+            except Exception:
+                pass
+            try:
+                fpath.unlink()
+            except Exception:
+                pass
+
+    merge("symbols", SYMBOLS_CACHE_PATH, lambda p: json.loads(p.read_text()))
+    merge("scanner_cache", SCANNER_CACHE_FILE, lambda p: json.loads(p.read_text()))
+    merge("gainers_cache", GAINERS_CACHE_FILE, lambda p: json.loads(p.read_text()))
+    merge("strategy_cache", STRATEGY_CACHE_FILE, _load_legacy_strategy_cache)
+    merge("selected_strategy", STRATEGY_NAME_FILE, lambda p: json.loads(p.read_text()))
+    merge("selected_scanner", SCANNER_NAME_FILE, lambda p: json.loads(p.read_text()))
+    merge("trade_amount", TRADE_AMOUNT_FILE, lambda p: json.loads(p.read_text()))
+    merge("onboarding", ONBOARD_FILE, lambda p: json.loads(p.read_text()))
+
+    if changed:
+        _save_combined(data, path)
+    return data
 
 
 def save_cache(symbol: str, df: pd.DataFrame) -> None:
@@ -48,64 +117,59 @@ def load_cache(symbol: str) -> pd.DataFrame:
 
 
 def save_scanner_cache(
-    rows: list[dict], path: pathlib.Path = SCANNER_CACHE_FILE
+    rows: list[dict], path: pathlib.Path = COMBINED_CACHE_FILE
 ) -> None:
-    try:
-        path.write_text(json.dumps({"t": time.time(), "rows": rows}, indent=0))
-    except Exception as exc:
-        log.error(f"cache write failed: {exc}")
+    data = _load_combined(path)
+    data["scanner_cache"] = {"t": time.time(), "rows": rows}
+    _save_combined(data, path)
 
 
-def load_scanner_cache(path: pathlib.Path = SCANNER_CACHE_FILE) -> list[dict]:
-    try:
-        blob = json.loads(path.read_text())
-        if time.time() - blob.get("t", 0) > 900:
-            return []
-        return blob.get("rows", [])
-    except Exception:
+def load_scanner_cache(path: pathlib.Path = COMBINED_CACHE_FILE) -> list[dict]:
+    data = _merge_legacy_caches(path)
+    blob = data.get("scanner_cache", {})
+    if not isinstance(blob, dict):
         return []
+    if time.time() - blob.get("t", 0) > 900:
+        return []
+    return blob.get("rows", [])
 
 
 def save_gainers_cache(
-    rows: list[dict], path: pathlib.Path = GAINERS_CACHE_FILE
+    rows: list[dict], path: pathlib.Path = COMBINED_CACHE_FILE
 ) -> None:
-    try:
-        path.write_text(json.dumps({"t": time.time(), "rows": rows}, indent=0))
-    except Exception as exc:
-        log.error(f"gainers cache write failed: {exc}")
+    data = _load_combined(path)
+    data["gainers_cache"] = {"t": time.time(), "rows": rows}
+    _save_combined(data, path)
 
 
-def load_gainers_cache(path: pathlib.Path = GAINERS_CACHE_FILE) -> list[dict]:
-    try:
-        blob = json.loads(path.read_text())
-        if time.time() - blob.get("t", 0) > 900:
-            return []
-        return blob.get("rows", [])
-    except Exception:
+def load_gainers_cache(path: pathlib.Path = COMBINED_CACHE_FILE) -> list[dict]:
+    data = _merge_legacy_caches(path)
+    blob = data.get("gainers_cache", {})
+    if not isinstance(blob, dict):
         return []
+    if time.time() - blob.get("t", 0) > 900:
+        return []
+    return blob.get("rows", [])
 
 
 def save_strategy_cache(
-    rows: list[dict], path: pathlib.Path = STRATEGY_CACHE_FILE
+    rows: list[dict], path: pathlib.Path = COMBINED_CACHE_FILE
 ) -> None:
-    try:
-        out = []
-        for rec in rows:
-            out_rec = dict(rec)
-            ts = out_rec.get("time")
-            if isinstance(ts, datetime):
-                out_rec["time"] = ts.isoformat()
-            out.append(out_rec)
-        path.write_text(json.dumps(out, indent=0))
-    except Exception as exc:
-        log.error(f"strategy cache write failed: {exc}")
+    out = []
+    for rec in rows:
+        out_rec = dict(rec)
+        ts = out_rec.get("time")
+        if isinstance(ts, datetime):
+            out_rec["time"] = ts.isoformat()
+        out.append(out_rec)
+    data = _load_combined(path)
+    data["strategy_cache"] = out
+    _save_combined(data, path)
 
 
-def load_strategy_cache(path: pathlib.Path = STRATEGY_CACHE_FILE) -> list[dict]:
-    try:
-        rows = json.loads(path.read_text())
-    except Exception:
-        return []
+def load_strategy_cache(path: pathlib.Path = COMBINED_CACHE_FILE) -> list[dict]:
+    data = _merge_legacy_caches(path)
+    rows = data.get("strategy_cache", [])
     out = []
     for rec in rows:
         if isinstance(rec, dict):
@@ -120,7 +184,7 @@ def load_strategy_cache(path: pathlib.Path = STRATEGY_CACHE_FILE) -> list[dict]:
 
 
 def record_signal(
-    cache_list: list[dict], sig: dict, path: pathlib.Path = STRATEGY_CACHE_FILE
+    cache_list: list[dict], sig: dict, path: pathlib.Path = COMBINED_CACHE_FILE
 ) -> None:
     cache_list.append(sig)
     save_strategy_cache(cache_list, path)
@@ -131,7 +195,7 @@ def attach_order_to_last_signal(
     symbol: str,
     side: str,
     order: object | None,
-    path: pathlib.Path = STRATEGY_CACHE_FILE,
+    path: pathlib.Path = COMBINED_CACHE_FILE,
 ) -> None:
     """Attach order details to the most recent matching signal."""
     if order is None:
@@ -169,7 +233,7 @@ def attach_order_to_last_signal(
 def update_order_statuses(
     cache_list: list[dict],
     orders: list,
-    path: pathlib.Path = STRATEGY_CACHE_FILE,
+    path: pathlib.Path = COMBINED_CACHE_FILE,
 ) -> None:
     """Refresh order status values in the strategy cache."""
 
@@ -208,83 +272,76 @@ def update_order_statuses(
 
 
 def save_symbols_cache(
-    symbols: list[str], path: pathlib.Path = SYMBOLS_CACHE_PATH
+    symbols: list[str], path: pathlib.Path = COMBINED_CACHE_FILE
 ) -> None:
-    try:
-        path.write_text(json.dumps(symbols))
-    except Exception as exc:
-        log.error(f"symbols cache write failed: {exc}")
+    data = _load_combined(path)
+    data["symbols"] = symbols
+    _save_combined(data, path)
 
 
-def load_symbols_cache(path: pathlib.Path = SYMBOLS_CACHE_PATH) -> list[str]:
-    try:
-        return json.loads(path.read_text())
-    except Exception:
-        return []
+def load_symbols_cache(path: pathlib.Path = COMBINED_CACHE_FILE) -> list[str]:
+    data = _merge_legacy_caches(path)
+    return data.get("symbols", [])
 
 
-def save_selected_strategy(name: str, path: pathlib.Path = STRATEGY_NAME_FILE) -> None:
+def save_selected_strategy(name: str, path: pathlib.Path = COMBINED_CACHE_FILE) -> None:
     """Persist the currently selected strategy name."""
-    try:
-        path.write_text(json.dumps(name))
-    except Exception as exc:
-        log.error(f"strategy name cache write failed: {exc}")
+    data = _load_combined(path)
+    data["selected_strategy"] = name
+    _save_combined(data, path)
 
 
-def load_selected_strategy(path: pathlib.Path = STRATEGY_NAME_FILE) -> str | None:
+def load_selected_strategy(path: pathlib.Path = COMBINED_CACHE_FILE) -> str | None:
     """Load the last selected strategy name from cache."""
-    try:
-        return json.loads(path.read_text())
-    except Exception:
-        return None
+    data = _merge_legacy_caches(path)
+    return data.get("selected_strategy")
 
 
-def save_selected_scanner(name: str, path: pathlib.Path = SCANNER_NAME_FILE) -> None:
+def save_selected_scanner(name: str, path: pathlib.Path = COMBINED_CACHE_FILE) -> None:
     """Persist the currently selected scanner name."""
-    try:
-        path.write_text(json.dumps(name))
-    except Exception as exc:
-        log.error(f"scanner name cache write failed: {exc}")
+    data = _load_combined(path)
+    data["selected_scanner"] = name
+    _save_combined(data, path)
 
 
-def load_selected_scanner(path: pathlib.Path = SCANNER_NAME_FILE) -> str | None:
+def load_selected_scanner(path: pathlib.Path = COMBINED_CACHE_FILE) -> str | None:
     """Load the last selected scanner name from cache."""
-    try:
-        return json.loads(path.read_text())
-    except Exception:
-        return None
+    data = _merge_legacy_caches(path)
+    return data.get("selected_scanner")
 
 
-ONBOARD_FILE = pathlib.Path.home() / ".spectr_onboard.json"
-
-
-def save_onboarding_config(config: dict, path: pathlib.Path = ONBOARD_FILE) -> None:
+def save_onboarding_config(
+    config: dict, path: pathlib.Path = COMBINED_CACHE_FILE
+) -> None:
     """Persist onboarding configuration."""
-    try:
-        path.write_text(json.dumps(config))
-    except Exception as exc:
-        log.error(f"onboarding cache write failed: {exc}")
+    data = _load_combined(path)
+    data["onboarding"] = config
+    _save_combined(data, path)
 
 
-def load_onboarding_config(path: pathlib.Path = ONBOARD_FILE) -> dict | None:
+def load_onboarding_config(path: pathlib.Path = COMBINED_CACHE_FILE) -> dict | None:
     """Load onboarding configuration if present."""
-    try:
-        return json.loads(path.read_text())
-    except Exception:
-        return None
+    data = _merge_legacy_caches(path)
+    return data.get("onboarding")
 
 
-def save_trade_amount(amount: float, path: pathlib.Path = TRADE_AMOUNT_FILE) -> None:
+def save_trade_amount(amount: float, path: pathlib.Path = COMBINED_CACHE_FILE) -> None:
     """Persist the last trade amount value."""
-    try:
-        path.write_text(json.dumps(float(amount)))
-    except Exception as exc:
-        log.error(f"trade amount cache write failed: {exc}")
+    data = _load_combined(path)
+    data["trade_amount"] = float(amount)
+    _save_combined(data, path)
 
 
-def load_trade_amount(path: pathlib.Path = TRADE_AMOUNT_FILE) -> float | None:
+def load_trade_amount(path: pathlib.Path = COMBINED_CACHE_FILE) -> float | None:
     """Load the cached trade amount if available."""
+    data = _merge_legacy_caches(path)
+    value = data.get("trade_amount")
+    if value is None:
+        return None
     try:
-        return float(json.loads(path.read_text()))
+        return float(value)
     except Exception:
         return None
+
+
+_merge_legacy_caches()

--- a/tests/test_cache_migration.py
+++ b/tests/test_cache_migration.py
@@ -1,0 +1,18 @@
+import json
+import importlib
+import pathlib
+from spectr import cache
+
+
+def test_merge_legacy(tmp_path, monkeypatch):
+    monkeypatch.setattr(pathlib.Path, "home", lambda: tmp_path)
+    # create legacy files
+    (tmp_path / ".spectr_scanner_cache.json").write_text(
+        json.dumps({"t": 1, "rows": [{"a": 1}]})
+    )
+    importlib.reload(cache)
+    combined = tmp_path / ".spectr_cache.json"
+    assert combined.exists()
+    data = json.loads(combined.read_text())
+    assert data["scanner_cache"]["rows"][0]["a"] == 1
+    assert not (tmp_path / ".spectr_scanner_cache.json").exists()

--- a/tests/test_trade_amount_cache.py
+++ b/tests/test_trade_amount_cache.py
@@ -3,8 +3,8 @@ from spectr import cache
 
 
 def test_trade_amount_cache(tmp_path, monkeypatch):
-    path = tmp_path / "amt.json"
-    monkeypatch.setattr(cache, "TRADE_AMOUNT_FILE", path)
-    cache.save_trade_amount(123.45)
+    path = tmp_path / "cache.json"
+    monkeypatch.setattr(cache, "COMBINED_CACHE_FILE", path, raising=False)
+    cache.save_trade_amount(123.45, path=path)
     assert path.exists()
-    assert cache.load_trade_amount() == 123.45
+    assert cache.load_trade_amount(path=path) == 123.45


### PR DESCRIPTION
## Summary
- add unified `.spectr_cache.json` and migrate legacy cache files
- adjust cache API to read/write from the combined file
- migrate legacy files automatically on import
- update trade amount test and add migration test

## Testing
- `pytest tests/test_trade_amount_cache.py tests/test_cache_migration.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866da68fd10832eac9d4cdb86497f01