### PR TITLE
Check for existing onboarding config on setup

### DIFF
--- a/src/spectr/views/setup_app.py
+++ b/src/spectr/views/setup_app.py
@@ -1,10 +1,13 @@
 from pathlib import Path
 from textual.app import App
 
+from .. import cache
 from .setup_dialog import SetupDialog
+
 
 class SetupApp(App):
     """Temporary app to collect setup information."""
+
     CSS_PATH = Path(__file__).resolve().parent.parent / "default.tcss"
 
     def __init__(self) -> None:
@@ -12,6 +15,11 @@ class SetupApp(App):
         self.result = None
 
     async def on_mount(self) -> None:
+        cfg = cache.load_onboarding_config()
+        if cfg:
+            self.result = cfg
+            self.exit()
+            return
         await self.push_screen(SetupDialog(self._on_submit), wait_for_dismiss=False)
 
     def _on_submit(

--- a/tests/test_setup_app.py
+++ b/tests/test_setup_app.py
@@ -1,0 +1,31 @@
+import json
+import asyncio
+import importlib
+import pathlib
+from spectr import cache
+from spectr.views.setup_app import SetupApp
+
+
+def test_setup_app_uses_cached_config(tmp_path, monkeypatch):
+    monkeypatch.setattr(pathlib.Path, "home", lambda: tmp_path)
+    cfg = {
+        "broker": "alpaca",
+        "paper": "alpaca",
+        "data_api": "fmp",
+        "broker_key": "b",
+        "broker_secret": "bs",
+        "paper_key": "p",
+        "paper_secret": "ps",
+        "data_key": "d",
+        "data_secret": "ds",
+        "openai_key": "o",
+    }
+    (tmp_path / ".spectr_onboard.json").write_text(json.dumps(cfg))
+    importlib.reload(cache)
+    app = SetupApp()
+
+    async def run_mount():
+        await app.on_mount()
+
+    asyncio.run(run_mount())
+    assert app.result == cfg


### PR DESCRIPTION
## Summary
- prevent showing the setup dialog when onboarding settings are already cached
- test using cached onboarding config

## Testing
- `pip install pandas numpy requests`
- `pip install alpaca-py robin_stocks yfinance matplotlib`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866dd0aa7b0832eab65efce972ed030