### PR TITLE
Add cache reset flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ PYTHONPATH=src python -m spectr.spectr --broker alpaca --data_api fmp --scale 0.
 | `--voice_agent_listen` | Enable real-time voice agent listening for the wake word. |
 | `--voice_agent_wake_word` | Word that triggers the voice agent (default: spectr). |
 | `--voice-streaming` | Enable streaming text-to-speech for the voice agent. |
+| `--reset-cache`     | Clear cached data on startup without removing saved credentials. |
 
 ---------------
 

--- a/src/spectr/cache.py
+++ b/src/spectr/cache.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import pathlib
+import shutil
 import time
 from datetime import datetime
 
@@ -342,6 +343,26 @@ def load_trade_amount(path: pathlib.Path = COMBINED_CACHE_FILE) -> float | None:
         return float(value)
     except Exception:
         return None
+
+
+def clear_cached_data(
+    path: pathlib.Path = COMBINED_CACHE_FILE, cache_dir: str = CACHE_DIR
+) -> None:
+    """Remove cached data while keeping onboarding credentials."""
+    data = _load_combined(path)
+    onboarding = data.get("onboarding")
+    if path.exists():
+        try:
+            path.unlink()
+        except Exception:
+            pass
+    if onboarding is not None:
+        _save_combined({"onboarding": onboarding}, path)
+    if os.path.isdir(cache_dir):
+        try:
+            shutil.rmtree(cache_dir)
+        except Exception:
+            pass
 
 
 _merge_legacy_caches()

--- a/src/spectr/cli.py
+++ b/src/spectr/cli.py
@@ -23,14 +23,22 @@ def main() -> None:
     parser.add_argument(
         "--candles", action="store_true", default=True, help="Show candlestick chart."
     )
-    parser.add_argument("--macd_thresh", type=float, default=0.002, help="MACD threshold")
-    parser.add_argument("--bb_period", type=int, default=200, help="Bollinger Band period")
-    parser.add_argument("--bb_dev", type=float, default=2.0, help="Bollinger Band std dev")
+    parser.add_argument(
+        "--macd_thresh", type=float, default=0.002, help="MACD threshold"
+    )
+    parser.add_argument(
+        "--bb_period", type=int, default=200, help="Bollinger Band period"
+    )
+    parser.add_argument(
+        "--bb_dev", type=float, default=2.0, help="Bollinger Band std dev"
+    )
     parser.add_argument(
         "--real_trades", action="store_true", help="Enable live trading (vs paper)"
     )
     parser.add_argument("--interval", default="1min")
-    parser.add_argument("--stop_loss_pct", type=float, default=0.01, help="Stop loss pct")
+    parser.add_argument(
+        "--stop_loss_pct", type=float, default=0.01, help="Stop loss pct"
+    )
     parser.add_argument(
         "--take_profit_pct", type=float, default=0.05, help="Take profit pct"
     )
@@ -53,7 +61,9 @@ def main() -> None:
         help="Choose which data provider to use (Alpaca, Robinhood, or FMP)",
     )
     parser.add_argument(
-        "--listen", action="store_true", help="Enable real-time voice agent listening for a wake word"
+        "--listen",
+        action="store_true",
+        help="Enable real-time voice agent listening for a wake word",
     )
     parser.add_argument(
         "--wake_word", default="spectr", help="Wake word that triggers the voice agent"
@@ -63,8 +73,16 @@ def main() -> None:
         action="store_true",
         help="Enable streaming text-to-speech for the voice agent",
     )
+    parser.add_argument(
+        "--reset-cache",
+        action="store_true",
+        help="Clear cached data before launching the app",
+    )
     parser.add_argument("--debug", action="store_true")
     args = parser.parse_args()
+
+    if args.reset_cache:
+        cache.clear_cached_data()
 
     if "--symbols" not in sys.argv:
         cached = cache.load_symbols_cache()
@@ -132,7 +150,9 @@ def main() -> None:
 
         appmod.BROKER_API = RobinhoodInterface()
     elif args.broker == "fmp":
-        raise ValueError("Invalid broker: FMP does not support broker services, only data.")
+        raise ValueError(
+            "Invalid broker: FMP does not support broker services, only data."
+        )
     else:
         raise ValueError(f"Unknown broker: {args.broker}")
 

--- a/tests/test_clear_cached_data.py
+++ b/tests/test_clear_cached_data.py
@@ -1,0 +1,17 @@
+import json
+from spectr import cache
+
+
+def test_clear_cached_data(tmp_path):
+    combined = tmp_path / "cache.json"
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    (cache_dir / ".AAPL.cache").write_text("dummy")
+    data = {"symbols": ["AAPL"], "onboarding": {"broker_key": "b"}}
+    combined.write_text(json.dumps(data))
+
+    cache.clear_cached_data(path=combined, cache_dir=str(cache_dir))
+
+    assert combined.exists()
+    assert json.loads(combined.read_text()) == {"onboarding": {"broker_key": "b"}}
+    assert not cache_dir.exists()


### PR DESCRIPTION
## Summary
- add `--reset-cache` flag to CLI to clear cached data
- preserve onboarding credentials when wiping cache
- document the new flag
- add tests for cache clearing

## Testing
- `pip install -q pandas requests pytz numpy tzlocal plotext openai black soundfile sounddevice robin_stocks`
- `pip install -q backtrader ta pygame alpaca-py textual[syntax]`
- `export PYTHONPATH=$(pwd)/src:$PYTHONPATH`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868022142e4832ebd553aa54bdccd19