### PR TITLE
Fix Alpaca crypto symbol formatting

### DIFF
--- a/tests/test_alpaca_symbol.py
+++ b/tests/test_alpaca_symbol.py
@@ -1,0 +1,16 @@
+import pytest
+from spectr.fetch.alpaca import _format_symbol
+
+
+@pytest.mark.parametrize(
+    "given,expected",
+    [
+        ("BTCUSD", "BTC/USD"),
+        ("ETHUSDT", "ETH/USDT"),
+        ("DOGEUSDC", "DOGE/USDC"),
+        ("AAPL", "AAPL"),
+        ("BTC/USD", "BTC/USD"),
+    ],
+)
+def test_format_symbol(given, expected):
+    assert _format_symbol(given) == expected


### PR DESCRIPTION
## Summary
- support formatted crypto symbols in Alpaca API
- add unit test for `_format_symbol`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68680cc81974832e9866a78257358a8d