### PR TITLE
Handle pending orders when detecting signals

### DIFF
--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -417,11 +417,17 @@ class SpectrApp(App):
                 position = BROKER_API.get_position(symbol)
 
             position = self._normalize_position(position)
+            orders = None
+            try:
+                orders = BROKER_API.get_pending_orders(symbol)
+            except Exception:
+                orders = None
 
             signal_dict = self.strategy_class.detect_signals(
                 df,
                 symbol,
                 position=position,
+                orders=orders,
             )
 
             # Check for signal

--- a/src/spectr/strategies/awesome_oscillator.py
+++ b/src/spectr/strategies/awesome_oscillator.py
@@ -2,7 +2,7 @@ import logging
 from typing import Optional
 
 import pandas as pd
-from .trading_strategy import TradingStrategy, IndicatorSpec
+from .trading_strategy import TradingStrategy, IndicatorSpec, get_order_sides
 
 log = logging.getLogger(__name__)
 
@@ -27,6 +27,7 @@ class AwesomeOscillator(TradingStrategy):
         df: pd.DataFrame,
         symbol: str,
         position: Optional[object] = None,
+        orders=None,
         *,
         fast_period: int = 5,
         slow_period: int = 34,
@@ -99,6 +100,9 @@ class AwesomeOscillator(TradingStrategy):
                 reason = "MA crossunder"
 
         if signal:
+            sides = get_order_sides(orders)
+            if signal.lower() in sides:
+                return None
             return {
                 "signal": signal,
                 "price": price,

--- a/src/spectr/strategies/custom_strategy.py
+++ b/src/spectr/strategies/custom_strategy.py
@@ -4,7 +4,7 @@ from typing import Optional
 import pandas as pd
 
 from . import metrics
-from .trading_strategy import TradingStrategy, IndicatorSpec
+from .trading_strategy import TradingStrategy, IndicatorSpec, get_order_sides
 
 log = logging.getLogger(__name__)
 
@@ -31,6 +31,7 @@ class CustomStrategy(TradingStrategy):
         df: pd.DataFrame,
         symbol: str,
         position=None,
+        orders=None,
         stop_loss_pct: float = 0.01,
         take_profit_pct: float = 0.05,
         bb_period: int = 20,
@@ -85,6 +86,9 @@ class CustomStrategy(TradingStrategy):
                 reason = "Price below BB mid"
 
         if signal:
+            sides = get_order_sides(orders)
+            if signal.lower() in sides:
+                return None
             return {
                 "signal": signal,
                 "price": price,

--- a/src/spectr/strategies/dual_thrust.py
+++ b/src/spectr/strategies/dual_thrust.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 import pandas as pd
 import numpy as np
-from .trading_strategy import TradingStrategy, IndicatorSpec
+from .trading_strategy import TradingStrategy, IndicatorSpec, get_order_sides
 
 log = logging.getLogger(__name__)
 
@@ -35,6 +35,7 @@ class DualThrust(TradingStrategy):
         df: pd.DataFrame,
         symbol: str,
         position: Optional[object] = None,
+        orders=None,
         *,
         k: float = 0.5,
         window: int = 4,
@@ -108,6 +109,9 @@ class DualThrust(TradingStrategy):
                 reason = "Reverse at upper"
 
         if signal:
+            sides = get_order_sides(orders)
+            if signal.lower() in sides:
+                return None
             return {
                 "signal": signal,
                 "price": price,

--- a/src/spectr/strategies/macd_oscillator.py
+++ b/src/spectr/strategies/macd_oscillator.py
@@ -2,7 +2,7 @@ import logging
 from typing import Optional
 
 import pandas as pd
-from .trading_strategy import TradingStrategy, IndicatorSpec
+from .trading_strategy import TradingStrategy, IndicatorSpec, get_order_sides
 
 log = logging.getLogger(__name__)
 
@@ -27,6 +27,7 @@ class MACDOscillator(TradingStrategy):
         df: pd.DataFrame,
         symbol: str,
         position: Optional[object] = None,
+        orders=None,
         *,
         fast_period: int = 12,
         slow_period: int = 26,
@@ -70,6 +71,9 @@ class MACDOscillator(TradingStrategy):
                 reason = "Oscillator crossed below zero"
 
         if signal:
+            sides = get_order_sides(orders)
+            if signal.lower() in sides:
+                return None
             return {
                 "signal": signal,
                 "price": price,


### PR DESCRIPTION
## Summary
- ignore signals if an order for the same side is pending
- provide helper `get_order_sides` for strategies
- pass open orders into `detect_signals`

## Testing
- `pip install ta==0.11.0`
- `pip install yfinance matplotlib pygame backtrader alpaca-py`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68681072c720832e861dfccf956cd180