### PR TITLE
Fix crypto quote URL for Alpaca

### DIFF
--- a/tests/test_alpaca_quote.py
+++ b/tests/test_alpaca_quote.py
@@ -1,0 +1,28 @@
+from types import SimpleNamespace
+import spectr.fetch.alpaca as alpaca
+
+
+def test_fetch_quote_crypto(monkeypatch):
+    called = {}
+
+    class DummyClient:
+        def __init__(self, *a, **kw):
+            called["init"] = True
+
+        def get_crypto_latest_quote(self, req):
+            called["symbol"] = req.symbol_or_symbols
+            return {
+                req.symbol_or_symbols: SimpleNamespace(ask_price=10.0, bid_price=9.0)
+            }
+
+    class FailStockClient:
+        def __init__(self, *a, **kw):
+            raise AssertionError("stock client used")
+
+    monkeypatch.setattr(alpaca, "CryptoHistoricalDataClient", DummyClient)
+    monkeypatch.setattr(alpaca, "StockHistoricalDataClient", FailStockClient)
+
+    iface = alpaca.AlpacaInterface()
+    q = iface.fetch_quote("BTCUSD")
+    assert q == {"ask": 10.0, "bid": 9.0, "price": 10.0}
+    assert called["symbol"] == "BTC/USD"


### PR DESCRIPTION
## Summary
- use CryptoHistoricalDataClient for crypto quotes
- add regression test for crypto quote fetch

## Testing
- `black src/spectr/fetch/alpaca.py tests/test_alpaca_quote.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68681166561c832e920232af87612dfc