### PR TITLE
Fix graph refresh on strategy change

### DIFF
--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -1028,6 +1028,18 @@ class SpectrApp(App):
         self.strategy_name = name
         self.strategy_class = load_strategy(name)
         cache.save_selected_strategy(name)
+
+        # Re-analyze any cached data using the newly selected strategy
+        specs = self.strategy_class.get_indicators()
+        for sym, df in list(self.df_cache.items()):
+            if df is not None and not df.empty:
+                try:
+                    self.df_cache[sym] = metrics.analyze_indicators(df, specs)
+                except Exception:
+                    log.error("Failed to update indicators for %s", sym)
+
+        current = self.ticker_symbols[self.active_symbol_index]
+        self.update_view(current)
         self.update_status_bar()
 
     def set_scanner(self, name: str) -> None:

--- a/tests/test_set_strategy.py
+++ b/tests/test_set_strategy.py
@@ -1,0 +1,62 @@
+import pandas as pd
+from types import SimpleNamespace
+
+from spectr.strategies.trading_strategy import IndicatorSpec
+from spectr.strategies import metrics
+from spectr.spectr import SpectrApp
+
+
+def _dummy_df():
+    idx = pd.date_range("2024-01-01", periods=2, freq="min")
+    return pd.DataFrame(
+        {
+            "open": [1, 1],
+            "high": [1, 1],
+            "low": [1, 1],
+            "close": [1, 1],
+            "volume": [1, 1],
+        },
+        index=idx,
+    )
+
+
+def test_set_strategy_updates_cache(monkeypatch):
+    df = _dummy_df()
+    new_col = "added"
+
+    def fake_analyze(data, specs):
+        data = data.copy()
+        data[new_col] = 1
+        return data
+
+    monkeypatch.setattr(metrics, "analyze_indicators", fake_analyze)
+
+    updated = []
+
+    def fake_update_view(symbol):
+        updated.append(symbol)
+
+    app = SimpleNamespace(
+        available_strategies={"Old": object(), "New": object()},
+        strategy_name="Old",
+        strategy_class=SimpleNamespace(
+            get_indicators=lambda: [IndicatorSpec(name="MACD", params={})]
+        ),
+        df_cache={"SYM": df},
+        ticker_symbols=["SYM"],
+        active_symbol_index=0,
+        update_status_bar=lambda: None,
+        update_view=fake_update_view,
+    )
+
+    def fake_load_strategy(name):
+        return SimpleNamespace(
+            get_indicators=lambda: [IndicatorSpec(name="VWAP", params={})]
+        )
+
+    monkeypatch.setattr("spectr.spectr.load_strategy", fake_load_strategy)
+
+    SpectrApp.set_strategy(app, "New")
+
+    assert new_col in app.df_cache["SYM"]
+    assert updated == ["SYM"]


### PR DESCRIPTION
## Summary
- re-analyze cached data when the strategy changes so the graph updates
- add regression test for `set_strategy`

## Testing
- `pytest tests/test_symbol_view.py tests/test_set_strategy.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68682ee3e7ac832eba42a48c2be605a0