### PR TITLE
Fix voice agent restart bug

### DIFF
--- a/src/spectr/agent.py
+++ b/src/spectr/agent.py
@@ -623,6 +623,7 @@ class VoiceAgent:
                 self._on_speech_end()
             except Exception:
                 pass
+        self._stop_event.clear()
 
     def _speech_worker(self) -> None:
         while True:

--- a/tests/test_voice_agent.py
+++ b/tests/test_voice_agent.py
@@ -1,0 +1,15 @@
+import spectr.agent as agent
+
+
+class DummyOpenAI:
+    def __init__(self, api_key=None):
+        pass
+
+
+def test_stop_clears_event(monkeypatch):
+    monkeypatch.setattr(agent, "OpenAI", DummyOpenAI)
+    monkeypatch.setattr(agent.pygame.mixer, "init", lambda: None)
+    va = agent.VoiceAgent()
+    va._stop_event.set()
+    va.stop()
+    assert not va._stop_event.is_set()


### PR DESCRIPTION
## Summary
- fix toggle voice assistant to clear stop event so it can restart
- add regression test for VoiceAgent.stop()

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68682f91bd20832e85cb53d9ce543d8b