### PR TITLE
Add Ctrl-D shortcut for removing symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ BYOS - Bring Your Own Strategy. You must implement your own trading strategy in 
 - 👁️ Broker API support (Alpaca, Robinhood (in progress))
 - 🧠 Supports MACD, Bollinger Bands, and Volume / VWAP.
 - 📈 Advanced hot-keys for quick sells of current position: 100% - `Ctrl+Z`, 50% - `Ctrl+X`, and 25% - `Ctrl+C`.
+- 🗑️ Remove the current symbol from the watch list with `Ctrl+D`.
 - 💾 Symbols list automatically saved between sessions
 - 📌 Any stocks you currently own are automatically kept in the watchlist
 - 🔄 Scanner that filters top 50 gainers for favorable conditions.
@@ -69,6 +70,7 @@ Currently focusing on Alpaca for broker and FMP for data. Robinhood currently br
 | `Ctrl+Z` | Sell 100% of position          |
 | `Ctrl+X` | Sell 50% of position           |
 | `Ctrl+C` | Sell 25% of position           |
+| `Ctrl+D` | Remove current symbol from watch list |
 
 
 ## 📦 Installation

--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -115,6 +115,11 @@ class SpectrApp(App):
             "sell_quarter_current_symbol",
             "Opens sell dialog for current symbol, set to 25% of position",
         ),
+        (
+            "ctrl+d",
+            "remove_current_symbol",
+            "Remove the active symbol from the watchlist",
+        ),
         ("1", "select_symbol('1')", "Symbol 1"),
         ("2", "select_symbol('2')", "Symbol 2"),
         ("3", "select_symbol('3')", "Symbol 3"),
@@ -777,6 +782,16 @@ class SpectrApp(App):
                 default_limit_price=limit_price,
             )
         )
+
+    def action_remove_current_symbol(self) -> None:
+        """Remove the active symbol from the watchlist."""
+        if self._is_splash_active():
+            return
+        self._exit_backtest()
+        if not self.ticker_symbols:
+            return
+        symbol = self.ticker_symbols[self.active_symbol_index]
+        self.remove_symbol(symbol)
 
     # ------------ Arm / Dis-arm -------------
 

--- a/tests/test_remove_symbol_action.py
+++ b/tests/test_remove_symbol_action.py
@@ -1,0 +1,21 @@
+from spectr.spectr import SpectrApp
+from types import SimpleNamespace
+
+
+def test_ctrl_d_binding_present():
+    assert any(
+        b[0] == "ctrl+d" and b[1] == "remove_current_symbol" for b in SpectrApp.BINDINGS
+    )
+
+
+def test_action_remove_current_symbol(monkeypatch):
+    removed = []
+    app = SimpleNamespace(
+        ticker_symbols=["A", "B"],
+        active_symbol_index=0,
+        remove_symbol=lambda sym: removed.append(sym),
+        _exit_backtest=lambda: None,
+        _is_splash_active=lambda: False,
+    )
+    SpectrApp.action_remove_current_symbol(app)
+    assert removed == ["A"]


### PR DESCRIPTION
## Summary
- add `ctrl+d` binding in SpectrApp to remove the active symbol
- implement `action_remove_current_symbol`
- document new shortcut in README
- test that binding and action exist

## Testing
- `black -q src/spectr/spectr.py tests/test_remove_symbol_action.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'spectr')*

------
https://chatgpt.com/codex/tasks/task_e_686beb0d113c832e94b9beb37d6e2881