### PR TITLE
Add Afterhours toggle to portfolio

### DIFF
--- a/src/spectr/views/portfolio_screen.py
+++ b/src/spectr/views/portfolio_screen.py
@@ -39,6 +39,7 @@ class PortfolioScreen(Screen):
     portfolio_value = reactive(0.0)
     real_trades = reactive(False)
     trade_amount = reactive(0.0)
+    afterhours_enabled = reactive(True)
 
     def __init__(
         self,
@@ -55,6 +56,8 @@ class PortfolioScreen(Screen):
         hide_live_switch: bool = False,
         auto_trading: bool = False,
         set_auto_trading_cb=None,
+        afterhours_enabled: bool = True,
+        set_afterhours_cb=None,
         balance_callback=None,
         positions_callback=None,
         equity_data: Optional[list] = None,
@@ -86,6 +89,8 @@ class PortfolioScreen(Screen):
         self._set_real_trades_cb = set_real_trades_cb
         self.auto_trading_enabled = auto_trading
         self._set_auto_trading_cb = set_auto_trading_cb
+        self.afterhours_enabled = afterhours_enabled
+        self._set_afterhours_cb = set_afterhours_cb
         self._cancel_order_cb = cancel_order_callback
         self.trade_amount = trade_amount
         self._set_trade_amount_cb = set_trade_amount_cb
@@ -124,6 +129,9 @@ class PortfolioScreen(Screen):
         self.mode_switch.disabled = self.disable_live_switch
         self.auto_switch = Switch(
             value=self.auto_trading_enabled, id="auto-trade-switch"
+        )
+        self.afterhours_switch = Switch(
+            value=self.afterhours_enabled, id="afterhours-switch"
         )
         self.orders_callback = orders_callback
         self.balance_callback = balance_callback
@@ -226,6 +234,11 @@ class PortfolioScreen(Screen):
                 ),
                 Container(
                     Static("Auto Trades"), self.auto_switch, id="trade-switch-container"
+                ),
+                Container(
+                    Static("Afterhours"),
+                    self.afterhours_switch,
+                    id="afterhours-switch-container",
                 ),
                 id="trade-mode-container",
             ),
@@ -408,6 +421,10 @@ class PortfolioScreen(Screen):
             self.auto_trading_enabled = event.value
             if callable(self._set_auto_trading_cb):
                 self._set_auto_trading_cb(event.value)
+        elif event.switch.id == "afterhours-switch":
+            self.afterhours_enabled = event.value
+            if callable(self._set_afterhours_cb):
+                self._set_afterhours_cb(event.value)
 
     async def on_input_changed(self, event: Input.Changed) -> None:
         if event.input.id == "trade-amount-input":

--- a/tests/test_afterhours_toggle.py
+++ b/tests/test_afterhours_toggle.py
@@ -1,0 +1,90 @@
+import pandas as pd
+from types import SimpleNamespace
+import spectr.spectr as appmod
+from spectr.spectr import SpectrApp
+
+
+def _dummy_df():
+    idx = pd.date_range("2024-01-01", periods=1, freq="min")
+    return pd.DataFrame(
+        {
+            "open": [1],
+            "high": [1],
+            "low": [1],
+            "close": [1],
+            "volume": [1],
+        },
+        index=idx,
+    )
+
+
+def test_handle_signal_afterhours_disabled(monkeypatch):
+    df = _dummy_df()
+    calls = []
+
+    app = SimpleNamespace(
+        auto_trading_enabled=True,
+        afterhours_enabled=False,
+        trade_amount=0.0,
+        voice_agent=SimpleNamespace(say=lambda *a, **k: None),
+        signal_detected=[],
+        call_from_thread=lambda func, *a, **k: func(*a, **k),
+        strategy_signals=[],
+        strategy_name="Test",
+    )
+
+    monkeypatch.setattr(
+        appmod, "BROKER_API", SimpleNamespace(has_pending_order=lambda s: False)
+    )
+    monkeypatch.setattr(
+        appmod.broker_tools, "submit_order", lambda *a, **k: calls.append(True)
+    )
+    monkeypatch.setattr(appmod.utils, "is_market_open_now", lambda: False)
+    monkeypatch.setattr(appmod.cache, "record_signal", lambda *a, **k: None)
+
+    SpectrApp._handle_signal(
+        app,
+        "AAA",
+        df,
+        {"price": 10.0},
+        {"signal": "buy", "reason": "test"},
+    )
+
+    assert calls == []
+    assert app.signal_detected == [("AAA", 10.0, "buy", "test")]
+
+
+def test_handle_signal_afterhours_enabled(monkeypatch):
+    df = _dummy_df()
+    calls = []
+
+    app = SimpleNamespace(
+        auto_trading_enabled=True,
+        afterhours_enabled=True,
+        trade_amount=0.0,
+        voice_agent=SimpleNamespace(say=lambda *a, **k: None),
+        signal_detected=[],
+        call_from_thread=lambda func, *a, **k: func(*a, **k),
+        strategy_signals=[],
+        strategy_name="Test",
+    )
+
+    monkeypatch.setattr(
+        appmod, "BROKER_API", SimpleNamespace(has_pending_order=lambda s: False)
+    )
+    monkeypatch.setattr(
+        appmod.broker_tools, "submit_order", lambda *a, **k: calls.append(True)
+    )
+    monkeypatch.setattr(appmod.utils, "is_market_open_now", lambda: False)
+    monkeypatch.setattr(appmod.cache, "record_signal", lambda *a, **k: None)
+
+    SpectrApp._handle_signal(
+        app,
+        "AAA",
+        df,
+        {"price": 10.0},
+        {"signal": "buy", "reason": "test"},
+    )
+
+    assert calls == [True]
+    assert app.signal_detected == []


### PR DESCRIPTION
## Summary
- add Afterhours switch to Portfolio screen
- expose afterhours setting in SpectrApp
- prevent auto trades when Afterhours disabled and market closed
- test signal handling with Afterhours toggle

## Testing
- `pip install -e .`
- `pip install alpaca-py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dc2ae8b0c832e92c253f75bb6a0cc