### PR TITLE
Fix order dialog quantity usage

### DIFF
--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -527,7 +527,9 @@ class SpectrApp(App):
                         if should_prompt and _sig and side:
                             log.debug(f"Signal detected, opening dialog: {msg}")
                             if BROKER_API.has_pending_order(_sym):
-                                log.warning(f"Pending order for {_sym}; ignoring signal!")
+                                log.warning(
+                                    f"Pending order for {_sym}; ignoring signal!"
+                                )
                                 self.signal_detected.remove(signal)
                                 continue
                             self.signal_detected.remove(signal)
@@ -535,7 +537,10 @@ class SpectrApp(App):
                                 self.screen_stack[-1], OrderDialog
                             ):
                                 self.open_order_dialog(
-                                    side=side, pos_pct=100.0, symbol=_sym, reason=_reason
+                                    side=side,
+                                    pos_pct=100.0,
+                                    symbol=_sym,
+                                    reason=_reason,
                                 )
                             continue
                     elif self.auto_trading_enabled and _sig and side:
@@ -958,6 +963,7 @@ class SpectrApp(App):
                 msg.price,
                 self.trade_amount,
                 self.auto_trading_enabled,
+                qty=msg.qty,
                 voice_agent=self.voice_agent,
                 buy_sound_path=BUY_SOUND_PATH,
                 sell_sound_path=SELL_SOUND_PATH,

--- a/tests/test_broker_tools.py
+++ b/tests/test_broker_tools.py
@@ -190,3 +190,21 @@ def test_submit_order_fraction_fallback(monkeypatch):
 
     assert broker.calls == [2.5, 2]
     assert broker.submitted["quantity"] == 2
+
+
+def test_submit_order_manual_qty(monkeypatch):
+    quote = {"ask": 10.0, "bid": 9.0}
+    broker = DummyBroker(qty=5, quote=quote)
+    monkeypatch.setattr(broker_tools, "is_market_open_now", lambda tz=None: True)
+
+    broker_tools.submit_order(
+        broker,
+        "NVDA",
+        OrderSide.BUY,
+        price=10.0,
+        trade_amount=50.0,
+        auto_trading_enabled=True,
+        qty=3.5,
+    )
+
+    assert broker.submitted["quantity"] == 3.5


### PR DESCRIPTION
## Summary
- pass user-entered quantity to submit_order
- allow broker_tools.submit_order to accept an optional `qty` param
- test using explicit quantity

## Testing
- `black src/spectr/broker_tools.py src/spectr/spectr.py tests/test_broker_tools.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_686fedddd2f0832eb10cd7bc8d169119