### PR TITLE
Fix after-hours limit orders

### DIFF
--- a/src/spectr/broker_tools.py
+++ b/src/spectr/broker_tools.py
@@ -93,6 +93,7 @@ def submit_order(
                 return
 
     try:
+        extended_hours = not is_market_open_now() and not is_crypto_symbol(symbol)
         order = broker.submit_order(
             symbol=symbol,
             side=side,
@@ -100,6 +101,7 @@ def submit_order(
             quantity=qty,
             limit_price=limit_price,
             market_price=price,
+            extended_hours=extended_hours,
         )
         if buy_sound_path and sell_sound_path:
             play_sound(buy_sound_path if side == OrderSide.BUY else sell_sound_path)
@@ -140,6 +142,7 @@ def submit_order(
                         quantity=fallback_qty,
                         limit_price=limit_price,
                         market_price=price,
+                        extended_hours=extended_hours,
                     )
                     if buy_sound_path and sell_sound_path:
                         play_sound(

--- a/src/spectr/fetch/alpaca.py
+++ b/src/spectr/fetch/alpaca.py
@@ -402,6 +402,7 @@ class AlpacaInterface(BrokerInterface):
         quantity: float | None = None,
         limit_price: float | None = None,
         market_price: float | None = None,
+        extended_hours: bool | None = None,
     ):
         log.debug(f"Attempting to submit {type.name}...")
         try:
@@ -420,6 +421,7 @@ class AlpacaInterface(BrokerInterface):
                     qty=quantity,
                     side=side.name.lower(),
                     time_in_force=tif,
+                    extended_hours=extended_hours,
                 )
                 price_used = market_price
             else:
@@ -429,6 +431,7 @@ class AlpacaInterface(BrokerInterface):
                     side=side.name.lower(),
                     time_in_force=tif,
                     limit_price=limit_price,
+                    extended_hours=extended_hours,
                 )
                 price_used = limit_price
 

--- a/src/spectr/fetch/broker_interface.py
+++ b/src/spectr/fetch/broker_interface.py
@@ -88,6 +88,7 @@ class BrokerInterface(ABC):
         quantity: float | None = None,
         limit_price: float | None = None,
         market_price: float | None = None,
+        extended_hours: bool | None = None,
     ):
         """Submit a buy/sell order and return the resulting order object."""
         pass

--- a/tests/test_broker_tools.py
+++ b/tests/test_broker_tools.py
@@ -26,6 +26,7 @@ class DummyBroker:
         limit_price=None,
         market_price=None,
         real_trades=False,
+        extended_hours=None,
     ):
         self.submitted = {
             "symbol": symbol,
@@ -35,6 +36,7 @@ class DummyBroker:
             "limit_price": limit_price,
             "market_price": market_price,
             "real_trades": real_trades,
+            "extended_hours": extended_hours,
         }
         return self.submitted
 
@@ -111,6 +113,7 @@ def test_submit_order_equity(monkeypatch, side, is_open, expected_type):
         auto_trading_enabled=True,
     )
     assert broker.submitted["type"] is expected_type
+    assert broker.submitted["extended_hours"] is (not is_open)
     if is_open:
         assert broker.submitted["limit_price"] is None
     else:
@@ -135,6 +138,7 @@ def test_submit_order_crypto(monkeypatch, is_open):
         auto_trading_enabled=True,
     )
     assert broker.submitted["type"] is OrderType.MARKET
+    assert broker.submitted["extended_hours"] is False
     assert broker.submitted["limit_price"] is None
 
 
@@ -159,6 +163,7 @@ class FractionFailBroker(DummyBroker):
         limit_price=None,
         market_price=None,
         real_trades=False,
+        extended_hours=None,
     ):
         self.calls.append(quantity)
         if len(self.calls) == 1 and not float(quantity).is_integer():
@@ -171,6 +176,7 @@ class FractionFailBroker(DummyBroker):
             limit_price=limit_price,
             market_price=market_price,
             real_trades=real_trades,
+            extended_hours=extended_hours,
         )
 
 
@@ -190,6 +196,7 @@ def test_submit_order_fraction_fallback(monkeypatch):
 
     assert broker.calls == [2.5, 2]
     assert broker.submitted["quantity"] == 2
+    assert broker.submitted["extended_hours"] is False
 
 
 def test_submit_order_manual_qty(monkeypatch):
@@ -208,3 +215,4 @@ def test_submit_order_manual_qty(monkeypatch):
     )
 
     assert broker.submitted["quantity"] == 3.5
+    assert broker.submitted["extended_hours"] is False


### PR DESCRIPTION
## Summary
- support `extended_hours` when submitting orders
- enable after-hours trades for Alpaca
- add `extended_hours` checks in broker tools tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687021beaf10832eba23415066b2105d