### PR TITLE
Fix broker auth fallback

### DIFF
--- a/src/spectr/fetch/fmp.py
+++ b/src/spectr/fetch/fmp.py
@@ -3,6 +3,7 @@ import os
 import pandas as pd
 import requests
 from dotenv import load_dotenv
+from .. import cache
 from datetime import datetime, timedelta, timezone
 
 from tzlocal import get_localzone
@@ -11,6 +12,7 @@ from .data_interface import DataInterface
 from ..exceptions import DataApiRateLimitError
 
 load_dotenv()
+CFG = cache.load_onboarding_config() or {}
 
 # Prefer the generic DATA_API_KEY environment variable set by the onboarding
 # dialog, but fall back to the legacy FMP_API_KEY if present for backwards
@@ -20,7 +22,7 @@ load_dotenv()
 
 
 def _get_api_key() -> str | None:
-    return os.getenv("DATA_API_KEY") or os.getenv("FMP_API_KEY")
+    return os.getenv("DATA_API_KEY") or CFG.get("data_key") or os.getenv("FMP_API_KEY")
 
 
 log = logging.getLogger(__name__)

--- a/src/spectr/fetch/robinhood.py
+++ b/src/spectr/fetch/robinhood.py
@@ -5,26 +5,32 @@ from datetime import datetime, timedelta, timezone
 import types
 from robin_stocks import robinhood as r
 from dotenv import load_dotenv
+from .. import cache
 
 from .broker_interface import BrokerInterface, OrderSide, OrderType
 from .data_interface import DataInterface
 
 log = logging.getLogger(__name__)
 load_dotenv()
+CFG = cache.load_onboarding_config() or {}
 
 # Credentials are supplied via the generic BROKER_* variables for broker usage.
 # If Robinhood is also the selected data provider (``DATA_PROVIDER``), allow the
 # generic data variables to supply the credentials.  Otherwise fall back to the
 # legacy ROBINHOOD_* names for compatibility.
-DATA_PROVIDER = os.getenv("DATA_PROVIDER")
+DATA_PROVIDER = os.getenv("DATA_PROVIDER") or CFG.get("data_api")
 ROBIN_USER = (
     os.getenv("BROKER_API_KEY")
+    or CFG.get("broker_key")
     or (os.getenv("DATA_API_KEY") if DATA_PROVIDER == "robinhood" else None)
+    or (CFG.get("data_key") if DATA_PROVIDER == "robinhood" else None)
     or os.getenv("ROBINHOOD_USERNAME")
 )
 ROBIN_PASS = (
     os.getenv("BROKER_SECRET")
+    or CFG.get("broker_secret")
     or (os.getenv("DATA_SECRET") if DATA_PROVIDER == "robinhood" else None)
+    or (CFG.get("data_secret") if DATA_PROVIDER == "robinhood" else None)
     or os.getenv("ROBINHOOD_PASSWORD")
 )
 

--- a/tests/test_cached_auth.py
+++ b/tests/test_cached_auth.py
@@ -1,0 +1,60 @@
+import importlib
+from spectr import cache
+
+
+def test_alpaca_uses_cached_creds(monkeypatch):
+    cfg = {
+        "broker_key": "bk",
+        "broker_secret": "bs",
+        "paper_key": "pk",
+        "paper_secret": "ps",
+        "data_key": "dk",
+        "data_secret": "ds",
+        "data_api": "alpaca",
+    }
+    for var in [
+        "BROKER_API_KEY",
+        "BROKER_SECRET",
+        "PAPER_API_KEY",
+        "PAPER_SECRET",
+        "DATA_API_KEY",
+        "DATA_SECRET",
+        "DATA_PROVIDER",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(cache, "load_onboarding_config", lambda: cfg)
+
+    import spectr.fetch.alpaca as alpaca
+
+    importlib.reload(alpaca)
+    assert alpaca.DATA_PROVIDER == "alpaca"
+    assert alpaca.API_KEY == "bk"
+    assert alpaca.SECRET_KEY == "bs"
+    assert alpaca.PAPER_KEY == "pk"
+    assert alpaca.PAPER_SECRET == "ps"
+
+
+def test_robinhood_uses_cached_creds(monkeypatch):
+    cfg = {
+        "broker_key": "user",
+        "broker_secret": "pass",
+        "data_key": "du",
+        "data_secret": "dp",
+        "data_api": "robinhood",
+    }
+    for var in [
+        "BROKER_API_KEY",
+        "BROKER_SECRET",
+        "DATA_API_KEY",
+        "DATA_SECRET",
+        "DATA_PROVIDER",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(cache, "load_onboarding_config", lambda: cfg)
+
+    import spectr.fetch.robinhood as rh
+
+    importlib.reload(rh)
+    assert rh.DATA_PROVIDER == "robinhood"
+    assert rh.ROBIN_USER == "user"
+    assert rh.ROBIN_PASS == "pass"


### PR DESCRIPTION
## Summary
- consult cached onboarding credentials when initializing broker modules
- cover using cached credentials for Alpaca and Robinhood

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871e1334ac4832e89d323cf19b03ba7