### PR TITLE
Add strategy activation workflow

### DIFF
--- a/src/spectr/cache.py
+++ b/src/spectr/cache.py
@@ -34,6 +34,7 @@ def _load_combined(path: pathlib.Path = COMBINED_CACHE_FILE) -> dict:
         pass
     return {}
 
+
 def _default(obj: object) -> object:
     """Fallback JSON serializer for unsupported types."""
     try:
@@ -54,11 +55,13 @@ def _default(obj: object) -> object:
 
     return str(obj)
 
+
 def _save_combined(data: dict, path: pathlib.Path = COMBINED_CACHE_FILE) -> None:
     try:
         path.write_text(json.dumps(data, indent=0, default=_default))
     except Exception as exc:  # pragma: no cover - logging only
         log.error(f"combined cache write failed: {exc}")
+
 
 def _load_legacy_strategy_cache(path: pathlib.Path) -> list[dict]:
     try:
@@ -303,7 +306,9 @@ def load_symbols_cache(path: pathlib.Path = COMBINED_CACHE_FILE) -> list[str]:
     return data.get("symbols", [])
 
 
-def save_selected_strategy(name: str, path: pathlib.Path = COMBINED_CACHE_FILE) -> None:
+def save_selected_strategy(
+    name: str | None, path: pathlib.Path = COMBINED_CACHE_FILE
+) -> None:
     """Persist the currently selected strategy name."""
     data = _load_combined(path)
     data["selected_strategy"] = name

--- a/src/spectr/views/strategy_screen.py
+++ b/src/spectr/views/strategy_screen.py
@@ -93,6 +93,7 @@ class StrategyScreen(Screen):
             Button("Outdent", id="strategy-outdent"),
             Button("Format", id="strategy-format"),
             Button("Save", id="strategy-save", variant="success"),
+            Button("Activate", id="strategy-activate", variant="primary"),
             id="strategy-toolbar",
         )
         code_scroll = VerticalScroll(self.code_widget, id="strategy-code")
@@ -113,8 +114,6 @@ class StrategyScreen(Screen):
             self.code_str = self.file_path.read_text(encoding="utf-8")
             self.code_widget.text = self.code_str
             self.code_widget.language = "python"
-            if callable(self.callback):
-                self.callback(event.value)
 
     async def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "strategy-undo":
@@ -129,6 +128,14 @@ class StrategyScreen(Screen):
             self._format_code()
         elif event.button.id == "strategy-save":
             await self._save_strategy()
+        elif event.button.id == "strategy-activate":
+            if callable(self.callback):
+                self.callback(self.current)
+            self.app.query_one("#overlay-text").flash_message(
+                "Strategy activated",
+                duration=3.0,
+                style="bold green",
+            )
 
     async def _save_strategy(self) -> None:
         """Write edits to disk and reload the strategy."""

--- a/tests/test_status_bar.py
+++ b/tests/test_status_bar.py
@@ -1,0 +1,18 @@
+from types import SimpleNamespace
+from spectr.spectr import SpectrApp
+from spectr.views.top_overlay import TopOverlay
+
+def test_update_status_bar_no_strategy():
+    overlay = TopOverlay()
+    app = SimpleNamespace(
+        auto_trading_enabled=False,
+        ticker_symbols=["AAA"],
+        active_symbol_index=0,
+        query_one=lambda *a, **k: overlay,
+        strategy_name=None,
+        strategy_class=None,
+    )
+
+    SpectrApp.update_status_bar(app)
+
+    assert "NO STRATEGY" in overlay.status_text


### PR DESCRIPTION
## Summary
- add Activate button to strategy screen and support callback
- handle None strategy in SpectrApp
- display strategy active status in the top overlay
- include simple test for overlay status with no active strategy

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687373a7c728832eaf3814a3c342be89