### PR TITLE
Add deactivate button to strategy screen

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ textual[syntax]
 plotext
 requests
 rich
-playsound
+playsound==1.2.2
 plotext~=5.3.2
 requests~=2.32.3
 rich~=14.0.0

--- a/src/spectr/views/strategy_screen.py
+++ b/src/spectr/views/strategy_screen.py
@@ -94,6 +94,7 @@ class StrategyScreen(Screen):
             Button("Format", id="strategy-format"),
             Button("Save", id="strategy-save", variant="success"),
             Button("Activate", id="strategy-activate", variant="primary"),
+            Button("Deactivate", id="strategy-deactivate", variant="warning"),
             id="strategy-toolbar",
         )
         code_scroll = VerticalScroll(self.code_widget, id="strategy-code")
@@ -135,6 +136,14 @@ class StrategyScreen(Screen):
                 "Strategy activated",
                 duration=3.0,
                 style="bold green",
+            )
+        elif event.button.id == "strategy-deactivate":
+            if callable(self.callback):
+                self.callback(None)
+            self.app.query_one("#overlay-text").flash_message(
+                "Strategy deactivated",
+                duration=3.0,
+                style="bold yellow",
             )
 
     async def _save_strategy(self) -> None:

--- a/tests/test_set_strategy.py
+++ b/tests/test_set_strategy.py
@@ -60,3 +60,26 @@ def test_set_strategy_updates_cache(monkeypatch):
 
     assert new_col in app.df_cache["SYM"]
     assert updated == ["SYM"]
+
+
+def test_set_strategy_none(monkeypatch):
+    saved = []
+    monkeypatch.setattr(
+        "spectr.cache.save_selected_strategy", lambda n: saved.append(n)
+    )
+    app = SimpleNamespace(
+        available_strategies={"Test": object()},
+        strategy_name="Test",
+        strategy_class=object(),
+        df_cache={},
+        ticker_symbols=["SYM"],
+        active_symbol_index=0,
+        update_status_bar=lambda: None,
+        update_view=lambda *a: None,
+    )
+
+    SpectrApp.set_strategy(app, None)
+
+    assert app.strategy_name is None
+    assert app.strategy_class is None
+    assert saved == [None]


### PR DESCRIPTION
## Summary
- add Deactivate button to strategy editor
- show message and call callback when deactivated
- ensure calling set_strategy(None) clears active strategy
- pin playsound to version 1.2.2
- test set_strategy(None) behavior

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687488a23308832e91a04dd751415c70