### PR TITLE
Fix Setup dialog cancel exit

### DIFF
--- a/src/spectr/views/portfolio_screen.py
+++ b/src/spectr/views/portfolio_screen.py
@@ -547,7 +547,8 @@ class PortfolioScreen(Screen):
             if result:
                 cfg = cache.load_onboarding_config() or {}
                 await self.app.push_screen(
-                    SetupDialog(self._on_setup_submit, cfg), wait_for_dismiss=True
+                    SetupDialog(self._on_setup_submit, cfg, exit_on_cancel=False),
+                    wait_for_dismiss=True,
                 )
         elif event.button.id == "close-button":
             self.app.pop_screen()

--- a/src/spectr/views/setup_dialog.py
+++ b/src/spectr/views/setup_dialog.py
@@ -42,10 +42,13 @@ class SetupDialog(ModalScreen):
             self.data_secret = data_secret
             self.openai_key = openai_key
 
-    def __init__(self, callback, defaults: dict | None = None) -> None:
+    def __init__(
+        self, callback, defaults: dict | None = None, *, exit_on_cancel: bool = True
+    ) -> None:
         super().__init__()
         self._callback = callback
         self._defaults = defaults or {}
+        self._exit_on_cancel = exit_on_cancel
 
     def compose(self) -> ComposeResult:
         yield VerticalScroll(
@@ -173,8 +176,11 @@ class SetupDialog(ModalScreen):
             secret_input.display = True
 
     def action_cancel(self) -> None:
-        """Exit the entire app when the dialog is cancelled."""
-        self.app.exit()
+        """Dismiss or exit when the dialog is cancelled."""
+        if self._exit_on_cancel:
+            self.app.exit()
+        else:
+            self.dismiss()
 
     def action_save(self) -> None:
         """Collect field values and exit with the result."""

--- a/tests/test_setup_dialog.py
+++ b/tests/test_setup_dialog.py
@@ -33,3 +33,18 @@ def test_setup_dialog_defaults():
             assert dlg.query_one("#data-select", Select).value == CFG["data_api"]
 
     asyncio.run(run())
+
+
+class CancelApp(App):
+    async def on_mount(self) -> None:
+        self.dlg = SetupDialog(lambda *a: None, exit_on_cancel=False)
+        await self.push_screen(self.dlg)
+
+
+def test_setup_dialog_cancel_dismisses():
+    async def run() -> None:
+        async with CancelApp().run_test() as pilot:
+            await pilot.press("escape")
+            assert not pilot.app._exit
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- prevent Setup dialog cancellation from exiting main app
- ensure portfolio screen passes new parameter
- test that cancelling Setup dialog keeps app running

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874a2c8ef6c832e9b3a1cd491834115