### PR TITLE
Fix Setup confirm dialog style

### DIFF
--- a/src/spectr/default.tcss
+++ b/src/spectr/default.tcss
@@ -224,6 +224,34 @@ SetupDialog {
 }
 
 
+/* ------- Setup Confirm Dialog ------- */
+
+SetupConfirmDialog {
+    align: center middle;
+}
+
+#setup_confirm_body {
+    width: 50%;
+    height: 20;
+    border: solid green;
+    padding: 1 2;
+    content-align-horizontal: center;
+    content-align-vertical: middle;
+    background: #1a1a1a;
+}
+#setup_confirm_body Static {
+    text-align: center;
+    padding: 1 0;
+}
+
+#setup_confirm_row {
+    width: 100%;
+    content-align-horizontal: center;
+    align: center middle;
+    margin: 1 0;
+}
+
+
 
 /* ------- Portfolio Screen ------- */
 


### PR DESCRIPTION
## Summary
- style the setup confirmation dialog like the other dialogs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874b1f2b5c8832e96d8fa21dda2b33a