### PR TITLE
Add overlay widget to extra screens

### DIFF
--- a/src/spectr/views/portfolio_screen.py
+++ b/src/spectr/views/portfolio_screen.py
@@ -19,6 +19,7 @@ from .. import cache
 from .equity_curve_view import EquityCurveView
 from .setup_confirm_dialog import SetupConfirmDialog
 from .setup_dialog import SetupDialog
+from .top_overlay import TopOverlay
 
 log = logging.getLogger(__name__)
 
@@ -225,6 +226,7 @@ class PortfolioScreen(Screen):
             self.order_table.add_row("Loading...", "", "", "", "", "", "", "", "", "")
 
     def compose(self):
+        yield TopOverlay(id="overlay-text")
         yield Vertical(
             self.top_title,
             Horizontal(

--- a/src/spectr/views/strategy_screen.py
+++ b/src/spectr/views/strategy_screen.py
@@ -9,6 +9,8 @@ from textual.widgets import DataTable, Static, Select, TextArea, Button
 from textual.containers import Vertical, VerticalScroll, Horizontal
 from textual.reactive import reactive
 
+from .top_overlay import TopOverlay
+
 
 class StrategyScreen(Screen):
     """Modal screen listing live strategy signals."""
@@ -45,6 +47,8 @@ class StrategyScreen(Screen):
         raise FileNotFoundError(f"Unable to locate file for strategy {name}")
 
     def compose(self):
+        yield TopOverlay(id="overlay-text")
+
         table = DataTable(zebra_stripes=True, id="signals-table")
         table.add_columns(
             "Date/Time",

--- a/src/spectr/views/ticker_input_dialog.py
+++ b/src/spectr/views/ticker_input_dialog.py
@@ -5,7 +5,9 @@ from textual import events
 from textual.widgets import Input, Label, Button, DataTable, Select
 from textual.containers import Vertical, Horizontal, Container
 from textual.screen import ModalScreen
+
 from .. import utils
+from .top_overlay import TopOverlay
 
 log = logging.getLogger(__name__)
 
@@ -52,6 +54,7 @@ class TickerInputDialog(ModalScreen):
         self.set_scanner_cb = set_scanner_cb
 
     def compose(self):
+        yield TopOverlay(id="overlay-text")
         yield Vertical(
             Label("Enter new ticker symbol list (up to 20):"),
             Horizontal(

--- a/tests/test_overlay_screens.py
+++ b/tests/test_overlay_screens.py
@@ -1,0 +1,69 @@
+import asyncio
+from textual.app import App
+
+from spectr.views.strategy_screen import StrategyScreen
+from spectr.views.portfolio_screen import PortfolioScreen
+from spectr.views.ticker_input_dialog import TickerInputDialog
+from spectr.views.top_overlay import TopOverlay
+
+
+class StrategyApp(App):
+    async def on_mount(self) -> None:
+        self.scr = StrategyScreen([], ["A"], "A")
+        await self.push_screen(self.scr)
+
+
+def test_strategy_screen_has_overlay():
+    async def run():
+        async with StrategyApp().run_test() as pilot:
+            assert isinstance(
+                pilot.app.scr.query_one("#overlay-text", TopOverlay), TopOverlay
+            )
+
+    asyncio.run(run())
+
+
+class PortfolioApp(App):
+    async def on_mount(self) -> None:
+        self.scr = PortfolioScreen(
+            0.0,
+            0.0,
+            0.0,
+            [],
+            [],
+            lambda *a, **k: [],
+            lambda *a, **k: None,
+            False,
+        )
+        await self.push_screen(self.scr)
+
+
+def test_portfolio_screen_has_overlay():
+    async def run():
+        async with PortfolioApp().run_test() as pilot:
+            assert isinstance(
+                pilot.app.scr.query_one("#overlay-text", TopOverlay), TopOverlay
+            )
+
+    asyncio.run(run())
+
+
+class TickerApp(App):
+    async def on_mount(self) -> None:
+        self.scr = TickerInputDialog(
+            lambda *a, **k: None,
+            lambda *a, **k: [],
+            scanner_names=["TEST"],
+            current_scanner="TEST",
+        )
+        await self.push_screen(self.scr)
+
+
+def test_ticker_dialog_has_overlay():
+    async def run():
+        async with TickerApp().run_test() as pilot:
+            assert isinstance(
+                pilot.app.scr.query_one("#overlay-text", TopOverlay), TopOverlay
+            )
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- show the status overlay on the Strategy screen
- show the status overlay on the Portfolio screen
- show the status overlay on the ticker input dialog
- test that these screens include the overlay widget

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874b6372910832e94b7efab9603f9ab