### PR TITLE
Improve error visibility on startup

### DIFF
--- a/src/spectr/default.tcss
+++ b/src/spectr/default.tcss
@@ -18,6 +18,10 @@ Screen {
     color: green;
     content-align: center middle;
 }
+#splash-msg {
+    text-align: center;
+    color: yellow;
+}
 
 
 

--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -168,6 +168,15 @@ class SpectrApp(App):
             self.screen_stack and isinstance(self.screen_stack[-1], SplashScreen)
         )
 
+    def _set_splash_message(self, text: str) -> None:
+        """Update the splash screen message if it is visible."""
+        if self._is_splash_active():
+            try:
+                splash = self.query_one("#splash", SplashScreen)
+                splash.update_message(text)
+            except Exception:
+                pass
+
     def _prepend_open_positions(self) -> None:
         """Ensure open position symbols are at the start of ``ticker_symbols``."""
         try:
@@ -369,6 +378,7 @@ class SpectrApp(App):
 
     async def on_mount(self, event: events.Mount) -> None:
         await self.push_screen(SplashScreen(id="splash"), wait_for_dismiss=False)
+        self._set_splash_message("Loading...")
         self.refresh()
 
         overlay = self.query_one("#overlay-text", TopOverlay)
@@ -473,11 +483,10 @@ class SpectrApp(App):
                         f"Strategy error: {exc}",
                         style="bold red",
                     )
+                    self._set_splash_message(f"Strategy error: {exc}")
 
                 self.call_from_thread(_flash_error)
                 self.call_from_thread(self.voice_agent.say, f"Strategy error: {exc}")
-                if self._is_splash_active():
-                    self.call_from_thread(self.pop_screen)
                 return
 
             # Check for signal

--- a/src/spectr/views/splash_screen.py
+++ b/src/spectr/views/splash_screen.py
@@ -1,6 +1,7 @@
 from textual import events
 from textual.screen import Screen
 from textual.widgets import Static
+from textual.reactive import reactive
 
 GHOST = """
                                                              ..:::.                                 
@@ -46,23 +47,35 @@ GHOST = """
 
 ASCII_HEIGHT = len(GHOST.strip("\n").splitlines())
 
+
 class SplashScreen(Screen):
     """Center-screen logo while data initialises."""
 
     FALLBACK_TEXT = "SPECTR"
+    message: reactive[str] = reactive("Loading...")
 
     def compose(self):
         self.logo = Static(id="logo-art", classes="center")
+        self.msg = Static(self.message, id="splash-msg", classes="center")
         yield self.logo
+        yield self.msg
 
     def on_mount(self) -> None:
         self._update_logo()
+        self.msg.update(self.message)
 
     def on_resize(self, event: events.Resize) -> None:  # noqa: D401
         self._update_logo()
+
+    def update_message(self, text: str) -> None:
+        """Update the message under the logo."""
+        self.message = text
 
     def _update_logo(self) -> None:
         if self.app.size.height < ASCII_HEIGHT:
             self.logo.update(self.FALLBACK_TEXT)
         else:
             self.logo.update(GHOST)
+
+    def watch_message(self, old: str, new: str) -> None:  # type: ignore[override]
+        self.msg.update(new)

--- a/tests/test_detect_signal_error.py
+++ b/tests/test_detect_signal_error.py
@@ -16,6 +16,7 @@ def test_poll_one_symbol_error(monkeypatch):
     )
 
     calls = {"said": [], "popped": False}
+    splash_msgs = []
 
     dummy_broker = SimpleNamespace(
         get_position=lambda symbol: None,
@@ -38,6 +39,7 @@ def test_poll_one_symbol_error(monkeypatch):
         active_symbol_index=0,
         _is_splash_active=lambda: True,
         pop_screen=lambda: calls.__setitem__("popped", True),
+        _set_splash_message=lambda text: splash_msgs.append(text),
         call_from_thread=lambda func, *a, **k: func(*a, **k),
         voice_agent=SimpleNamespace(
             say=lambda text, wait=False: calls["said"].append(text)
@@ -50,4 +52,5 @@ def test_poll_one_symbol_error(monkeypatch):
 
     assert overlay_msgs == ["Strategy error: boom"]
     assert calls["said"] == ["Strategy error: boom"]
-    assert calls["popped"]
+    assert splash_msgs == ["Strategy error: boom"]
+    assert not calls["popped"]


### PR DESCRIPTION
## Summary
- allow splash screen to display an extra message line
- show the message as `Loading...` by default
- update the splash screen message if strategy errors occur
- style splash message
- adjust tests for updated splash behaviour

## Testing
- `black src/spectr/views/splash_screen.py src/spectr/spectr.py tests/test_detect_signal_error.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68759a970914832ead80102d962f23a3