### PR TITLE
Ensure overlay shows status across screens

### DIFF
--- a/src/spectr/views/portfolio_screen.py
+++ b/src/spectr/views/portfolio_screen.py
@@ -271,6 +271,8 @@ class PortfolioScreen(Screen):
         )
 
     async def on_mount(self, event: events.Mount) -> None:
+        if hasattr(self.app, "update_status_bar"):
+            self.app.update_status_bar()
         # Fetch account data in the background so the dialog appears immediately
         asyncio.create_task(self._reload_account_data())
         asyncio.create_task(self._refresh_orders())

--- a/src/spectr/views/strategy_screen.py
+++ b/src/spectr/views/strategy_screen.py
@@ -4,6 +4,7 @@ import importlib
 import pathlib
 import black
 
+from textual import events
 from textual.screen import Screen
 from textual.widgets import DataTable, Static, Select, TextArea, Button
 from textual.containers import Vertical, VerticalScroll, Horizontal
@@ -111,6 +112,10 @@ class StrategyScreen(Screen):
             code_scroll,
             id="strategy-screen",
         )
+
+    async def on_mount(self, event: events.Mount) -> None:
+        if hasattr(self.app, "update_status_bar"):
+            self.app.update_status_bar()
 
     async def on_select_changed(self, event: Select.Changed):
         if event.select.id == "strategy-select":

--- a/src/spectr/views/ticker_input_dialog.py
+++ b/src/spectr/views/ticker_input_dialog.py
@@ -88,6 +88,8 @@ class TickerInputDialog(ModalScreen):
         )
 
     async def on_mount(self, event: events.Mount) -> None:
+        if hasattr(self.app, "update_status_bar"):
+            self.app.update_status_bar()
         input_widget = self.query_one("#ticker-input", Input)
         if hasattr(self.app, "ticker_symbols"):
             input_widget.value = ",".join(self.app.ticker_symbols)


### PR DESCRIPTION
## Summary
- refresh status bar when opening portfolio, strategy, and ticker dialogs
- only refresh if the running app provides `update_status_bar`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876ac85834c832eb47648dd62a5422e