### PR TITLE
Add strategy activation toggle

### DIFF
--- a/src/spectr/views/strategy_screen.py
+++ b/src/spectr/views/strategy_screen.py
@@ -142,19 +142,21 @@ class StrategyScreen(Screen):
         elif event.button.id == "strategy-activate":
             if callable(self.callback):
                 self.callback(self.current)
-            self.app.query_one("#overlay-text").flash_message(
-                "Strategy activated",
-                duration=3.0,
-                style="bold green",
-            )
+            if hasattr(self.app, "set_strategy_active"):
+                self.app.set_strategy_active(True)
+                self.app.query_one("#overlay-text").flash_message(
+                    "Strategy activated",
+                    duration=3.0,
+                    style="bold green",
+                )
         elif event.button.id == "strategy-deactivate":
-            if callable(self.callback):
-                self.callback(None)
-            self.app.query_one("#overlay-text").flash_message(
-                "Strategy deactivated",
-                duration=3.0,
-                style="bold yellow",
-            )
+            if hasattr(self.app, "set_strategy_active"):
+                self.app.set_strategy_active(False)
+                self.app.query_one("#overlay-text").flash_message(
+                    "Strategy deactivated",
+                    duration=3.0,
+                    style="bold yellow",
+                )
 
     async def _save_strategy(self) -> None:
         """Write edits to disk and reload the strategy."""

--- a/tests/test_detect_signal_error.py
+++ b/tests/test_detect_signal_error.py
@@ -44,6 +44,7 @@ def test_poll_one_symbol_error(monkeypatch):
         ),
         update_view=lambda sym: None,
         query_one=lambda sel, cls: overlay,
+        strategy_active=True,
     )
 
     SpectrApp._poll_one_symbol(app, "AAA")

--- a/tests/test_status_bar.py
+++ b/tests/test_status_bar.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 from spectr.spectr import SpectrApp
 from spectr.views.top_overlay import TopOverlay
 
+
 def test_update_status_bar_no_strategy():
     overlay = TopOverlay()
     app = SimpleNamespace(
@@ -16,3 +17,20 @@ def test_update_status_bar_no_strategy():
     SpectrApp.update_status_bar(app)
 
     assert "NO STRATEGY" in overlay.status_text
+
+
+def test_update_status_bar_inactive_strategy():
+    overlay = TopOverlay()
+    app = SimpleNamespace(
+        auto_trading_enabled=False,
+        ticker_symbols=["AAA"],
+        active_symbol_index=0,
+        query_one=lambda *a, **k: overlay,
+        strategy_name="Test",
+        strategy_class=object(),
+        strategy_active=False,
+    )
+
+    SpectrApp.update_status_bar(app)
+
+    assert "Test (INACTIVE)" in overlay.status_text

--- a/tests/test_strategy_active.py
+++ b/tests/test_strategy_active.py
@@ -1,0 +1,80 @@
+import pandas as pd
+from types import SimpleNamespace
+import asyncio
+from textual.app import App
+import spectr.spectr as appmod
+from spectr.spectr import SpectrApp
+from spectr.views.strategy_screen import StrategyScreen
+
+
+def test_poll_one_symbol_inactive(monkeypatch):
+    df = pd.DataFrame(
+        {"open": [1], "high": [1], "low": [1], "close": [1], "volume": [1]},
+        index=[pd.Timestamp("2024-01-01")],
+    )
+
+    dummy_broker = SimpleNamespace(
+        get_position=lambda symbol: None,
+        get_pending_orders=lambda symbol: None,
+    )
+    monkeypatch.setattr(appmod, "BROKER_API", dummy_broker)
+
+    calls = []
+
+    def detect(*a, **k):
+        calls.append(True)
+        return {"signal": "buy"}
+
+    overlay = SimpleNamespace(flash_message=lambda *a, **k: None)
+
+    app = SimpleNamespace(
+        _fetch_data=lambda sym, quote=None: (df, {"price": 1}),
+        _analyze_indicators=lambda d: d,
+        _normalize_position=lambda p: p,
+        strategy_class=SimpleNamespace(detect_signals=detect),
+        _handle_signal=lambda *a: None,
+        df_cache={},
+        _update_queue=SimpleNamespace(put=lambda sym: None),
+        ticker_symbols=["AAA"],
+        active_symbol_index=0,
+        _is_splash_active=lambda: False,
+        pop_screen=lambda: None,
+        call_from_thread=lambda func, *a, **k: func(*a, **k),
+        voice_agent=SimpleNamespace(say=lambda *a, **k: None),
+        update_view=lambda sym: None,
+        query_one=lambda sel, cls: overlay,
+        strategy_active=False,
+    )
+
+    SpectrApp._poll_one_symbol(app, "AAA")
+
+    assert calls == []
+
+
+def test_strategy_screen_buttons_toggle():
+    class ToggleApp(App):
+        def __init__(self) -> None:
+            super().__init__()
+            self.toggled = []
+
+        async def on_mount(self) -> None:
+            self.scr = StrategyScreen([], ["CustomStrategy"], "CustomStrategy")
+            await self.push_screen(self.scr)
+
+        def set_strategy_active(self, enabled: bool) -> None:
+            self.toggled.append(enabled)
+
+    async def run() -> None:
+        async with ToggleApp().run_test() as pilot:
+            screen = pilot.app.scr
+            overlay = SimpleNamespace(flash_message=lambda *a, **k: None)
+            pilot.app.query_one = lambda *a, **k: overlay
+            await screen.on_button_pressed(
+                SimpleNamespace(button=SimpleNamespace(id="strategy-activate"))
+            )
+            await screen.on_button_pressed(
+                SimpleNamespace(button=SimpleNamespace(id="strategy-deactivate"))
+            )
+            assert pilot.app.toggled == [True, False]
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- add `strategy_active` to track if the strategy should fire
- skip `detect_signals` when strategy is inactive
- expose `set_strategy_active` helper
- update StrategyScreen buttons to toggle `strategy_active`
- test inactive strategy behaviour and button toggles
- fix strategy screen flash message conditional

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877248310e4832eb7a741496dcf7522