### PR TITLE
Enable strategy when auto-trading is armed

### DIFF
--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -1147,6 +1147,8 @@ class SpectrApp(App):
     def set_auto_trading(self, enabled: bool) -> None:
         """Enable or disable auto trading mode."""
         self.auto_trading_enabled = enabled
+        if enabled:
+            self.set_strategy_active(True)
         # Update the portfolio screen toggle if it's currently visible
         if self.screen_stack and isinstance(self.screen_stack[-1], PortfolioScreen):
             screen = self.screen_stack[-1]

--- a/tests/test_strategy_active.py
+++ b/tests/test_strategy_active.py
@@ -78,3 +78,23 @@ def test_strategy_screen_buttons_toggle():
             assert pilot.app.toggled == [True, False]
 
     asyncio.run(run())
+
+
+def test_set_auto_trading_activates_strategy():
+    calls = []
+
+    def _set_strategy_active(enabled: bool) -> None:
+        calls.append(enabled)
+
+    app = SimpleNamespace(
+        auto_trading_enabled=False,
+        screen_stack=[],
+        query_one=lambda *a, **k: None,
+        update_status_bar=lambda: None,
+        set_strategy_active=_set_strategy_active,
+    )
+
+    SpectrApp.set_auto_trading(app, True)
+
+    assert app.auto_trading_enabled
+    assert calls == [True]


### PR DESCRIPTION
## Summary
- ensure enabling auto-trading automatically activates the strategy
- test that auto-trading activation switches the strategy on

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687749992844832e9f2133d04c6f966a