### PR TITLE
Refactor overlay usage

### DIFF
--- a/src/spectr/views/portfolio_screen.py
+++ b/src/spectr/views/portfolio_screen.py
@@ -19,7 +19,6 @@ from .. import cache
 from .equity_curve_view import EquityCurveView
 from .setup_confirm_dialog import SetupConfirmDialog
 from .setup_dialog import SetupDialog
-from .top_overlay import TopOverlay
 
 log = logging.getLogger(__name__)
 
@@ -226,7 +225,6 @@ class PortfolioScreen(Screen):
             self.order_table.add_row("Loading...", "", "", "", "", "", "", "", "", "")
 
     def compose(self):
-        yield TopOverlay(id="overlay-text")
         yield Vertical(
             self.top_title,
             Horizontal(

--- a/src/spectr/views/strategy_screen.py
+++ b/src/spectr/views/strategy_screen.py
@@ -10,8 +10,6 @@ from textual.widgets import DataTable, Static, Select, TextArea, Button
 from textual.containers import Vertical, VerticalScroll, Horizontal
 from textual.reactive import reactive
 
-from .top_overlay import TopOverlay
-
 
 class StrategyScreen(Screen):
     """Modal screen listing live strategy signals."""
@@ -48,8 +46,6 @@ class StrategyScreen(Screen):
         raise FileNotFoundError(f"Unable to locate file for strategy {name}")
 
     def compose(self):
-        yield TopOverlay(id="overlay-text")
-
         table = DataTable(zebra_stripes=True, id="signals-table")
         table.add_columns(
             "Date/Time",
@@ -144,7 +140,7 @@ class StrategyScreen(Screen):
                 self.callback(self.current)
             if hasattr(self.app, "set_strategy_active"):
                 self.app.set_strategy_active(True)
-                self.app.query_one("#overlay-text").flash_message(
+                self.app.overlay.flash_message(
                     "Strategy activated",
                     duration=3.0,
                     style="bold green",
@@ -152,7 +148,7 @@ class StrategyScreen(Screen):
         elif event.button.id == "strategy-deactivate":
             if hasattr(self.app, "set_strategy_active"):
                 self.app.set_strategy_active(False)
-                self.app.query_one("#overlay-text").flash_message(
+                self.app.overlay.flash_message(
                     "Strategy deactivated",
                     duration=3.0,
                     style="bold yellow",
@@ -169,11 +165,11 @@ class StrategyScreen(Screen):
                 importlib.import_module(module_name)
             if callable(self.callback):
                 self.callback(self.current)
-            self.app.query_one("#overlay-text").flash_message(
+            self.app.overlay.flash_message(
                 "Strategy saved", duration=3.0, style="bold green"
             )
         except Exception as exc:  # pragma: no cover - best effort
-            self.app.query_one("#overlay-text").flash_message(
+            self.app.overlay.flash_message(
                 f"Error saving: {exc}", duration=5.0, style="bold red"
             )
 
@@ -205,12 +201,12 @@ class StrategyScreen(Screen):
         try:
             formatted = black.format_str(self.code_widget.text, mode=black.FileMode())
         except Exception as exc:
-            self.app.query_one("#overlay-text").flash_message(
+            self.app.overlay.flash_message(
                 f"Format error: {exc}", duration=5.0, style="bold red"
             )
             return
         if formatted != self.code_widget.text:
             self.code_widget.text = formatted
-            self.app.query_one("#overlay-text").flash_message(
+            self.app.overlay.flash_message(
                 "Code formatted", duration=3.0, style="bold green"
             )

--- a/src/spectr/views/ticker_input_dialog.py
+++ b/src/spectr/views/ticker_input_dialog.py
@@ -7,7 +7,6 @@ from textual.containers import Vertical, Horizontal, Container
 from textual.screen import ModalScreen
 
 from .. import utils
-from .top_overlay import TopOverlay
 
 log = logging.getLogger(__name__)
 
@@ -54,7 +53,6 @@ class TickerInputDialog(ModalScreen):
         self.set_scanner_cb = set_scanner_cb
 
     def compose(self):
-        yield TopOverlay(id="overlay-text")
         yield Vertical(
             Label("Enter new ticker symbol list (up to 20):"),
             Horizontal(

--- a/tests/test_detect_signal_error.py
+++ b/tests/test_detect_signal_error.py
@@ -43,7 +43,7 @@ def test_poll_one_symbol_error(monkeypatch):
             say=lambda text, wait=False: calls["said"].append(text)
         ),
         update_view=lambda sym: None,
-        query_one=lambda sel, cls: overlay,
+        overlay=overlay,
         strategy_active=True,
     )
 

--- a/tests/test_overlay_screens.py
+++ b/tests/test_overlay_screens.py
@@ -8,6 +8,10 @@ from spectr.views.top_overlay import TopOverlay
 
 
 class StrategyApp(App):
+    def compose(self):
+        self.overlay = TopOverlay(id="overlay-text")
+        yield self.overlay
+
     async def on_mount(self) -> None:
         self.scr = StrategyScreen([], ["A"], "A")
         await self.push_screen(self.scr)
@@ -16,14 +20,16 @@ class StrategyApp(App):
 def test_strategy_screen_has_overlay():
     async def run():
         async with StrategyApp().run_test() as pilot:
-            assert isinstance(
-                pilot.app.scr.query_one("#overlay-text", TopOverlay), TopOverlay
-            )
+            assert isinstance(pilot.app.overlay, TopOverlay)
 
     asyncio.run(run())
 
 
 class PortfolioApp(App):
+    def compose(self):
+        self.overlay = TopOverlay(id="overlay-text")
+        yield self.overlay
+
     async def on_mount(self) -> None:
         self.scr = PortfolioScreen(
             0.0,
@@ -41,14 +47,16 @@ class PortfolioApp(App):
 def test_portfolio_screen_has_overlay():
     async def run():
         async with PortfolioApp().run_test() as pilot:
-            assert isinstance(
-                pilot.app.scr.query_one("#overlay-text", TopOverlay), TopOverlay
-            )
+            assert isinstance(pilot.app.overlay, TopOverlay)
 
     asyncio.run(run())
 
 
 class TickerApp(App):
+    def compose(self):
+        self.overlay = TopOverlay(id="overlay-text")
+        yield self.overlay
+
     async def on_mount(self) -> None:
         self.scr = TickerInputDialog(
             lambda *a, **k: None,
@@ -62,8 +70,6 @@ class TickerApp(App):
 def test_ticker_dialog_has_overlay():
     async def run():
         async with TickerApp().run_test() as pilot:
-            assert isinstance(
-                pilot.app.scr.query_one("#overlay-text", TopOverlay), TopOverlay
-            )
+            assert isinstance(pilot.app.overlay, TopOverlay)
 
     asyncio.run(run())

--- a/tests/test_status_bar.py
+++ b/tests/test_status_bar.py
@@ -9,7 +9,7 @@ def test_update_status_bar_no_strategy():
         auto_trading_enabled=False,
         ticker_symbols=["AAA"],
         active_symbol_index=0,
-        query_one=lambda *a, **k: overlay,
+        overlay=overlay,
         strategy_name=None,
         strategy_class=None,
     )
@@ -25,7 +25,7 @@ def test_update_status_bar_inactive_strategy():
         auto_trading_enabled=False,
         ticker_symbols=["AAA"],
         active_symbol_index=0,
-        query_one=lambda *a, **k: overlay,
+        overlay=overlay,
         strategy_name="Test",
         strategy_class=object(),
         strategy_active=False,

--- a/tests/test_strategy_active.py
+++ b/tests/test_strategy_active.py
@@ -42,7 +42,7 @@ def test_poll_one_symbol_inactive(monkeypatch):
         call_from_thread=lambda func, *a, **k: func(*a, **k),
         voice_agent=SimpleNamespace(say=lambda *a, **k: None),
         update_view=lambda sym: None,
-        query_one=lambda sel, cls: overlay,
+        overlay=overlay,
         strategy_active=False,
     )
 
@@ -68,7 +68,7 @@ def test_strategy_screen_buttons_toggle():
         async with ToggleApp().run_test() as pilot:
             screen = pilot.app.scr
             overlay = SimpleNamespace(flash_message=lambda *a, **k: None)
-            pilot.app.query_one = lambda *a, **k: overlay
+            pilot.app.overlay = overlay
             await screen.on_button_pressed(
                 SimpleNamespace(button=SimpleNamespace(id="strategy-activate"))
             )
@@ -89,7 +89,7 @@ def test_set_auto_trading_activates_strategy():
     app = SimpleNamespace(
         auto_trading_enabled=False,
         screen_stack=[],
-        query_one=lambda *a, **k: None,
+        overlay=None,
         update_status_bar=lambda: None,
         set_strategy_active=_set_strategy_active,
     )


### PR DESCRIPTION
## Summary
- instantiate `TopOverlay` once in `SpectrApp.compose`
- drop overlay widgets from several screens
- access overlay via `self.app.overlay`
- update tests for shared overlay widget

## Testing
- `black src/spectr/spectr.py src/spectr/views/portfolio_screen.py src/spectr/views/strategy_screen.py src/spectr/views/ticker_input_dialog.py tests/test_overlay_screens.py tests/test_status_bar.py tests/test_strategy_active.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687750b03aa0832e8e1ddffc31d5d863