### PR TITLE
Add stop loss and take profit

### DIFF
--- a/src/spectr/strategies/awesome_oscillator.py
+++ b/src/spectr/strategies/awesome_oscillator.py
@@ -2,7 +2,12 @@ import logging
 from typing import Optional
 
 import pandas as pd
-from .trading_strategy import TradingStrategy, IndicatorSpec, get_order_sides
+from .trading_strategy import (
+    TradingStrategy,
+    IndicatorSpec,
+    get_order_sides,
+    check_stop_levels,
+)
 
 log = logging.getLogger(__name__)
 
@@ -55,6 +60,15 @@ class AwesomeOscillator(TradingStrategy):
         price = float(curr.get("close", 0))
         signal = None
         reason = None
+
+        stop_signal = check_stop_levels(price, position, stop_loss_pct, take_profit_pct)
+        if stop_signal:
+            return {
+                "signal": stop_signal["signal"],
+                "price": price,
+                "symbol": symbol,
+                "reason": stop_signal["reason"],
+            }
 
         in_position = False
         if position is not None:

--- a/src/spectr/strategies/custom_strategy.py
+++ b/src/spectr/strategies/custom_strategy.py
@@ -4,7 +4,12 @@ from typing import Optional
 import pandas as pd
 
 from . import metrics
-from .trading_strategy import TradingStrategy, IndicatorSpec, get_order_sides
+from .trading_strategy import (
+    TradingStrategy,
+    IndicatorSpec,
+    get_order_sides,
+    check_stop_levels,
+)
 
 log = logging.getLogger(__name__)
 
@@ -47,6 +52,15 @@ class CustomStrategy(TradingStrategy):
         price = float(curr.get("close", 0))
         reason = None
         signal = None
+
+        stop_signal = check_stop_levels(price, position, stop_loss_pct, take_profit_pct)
+        if stop_signal:
+            return {
+                "signal": stop_signal["signal"],
+                "price": price,
+                "symbol": symbol,
+                "reason": stop_signal["reason"],
+            }
 
         if is_backtest:
             if (

--- a/src/spectr/strategies/dual_thrust.py
+++ b/src/spectr/strategies/dual_thrust.py
@@ -4,7 +4,12 @@ from datetime import datetime
 
 import pandas as pd
 import numpy as np
-from .trading_strategy import TradingStrategy, IndicatorSpec, get_order_sides
+from .trading_strategy import (
+    TradingStrategy,
+    IndicatorSpec,
+    get_order_sides,
+    check_stop_levels,
+)
 
 log = logging.getLogger(__name__)
 
@@ -77,6 +82,15 @@ class DualThrust(TradingStrategy):
         signal = None
         reason = None
         price = float(curr.get("close", 0))
+
+        stop_signal = check_stop_levels(price, position, stop_loss_pct, take_profit_pct)
+        if stop_signal:
+            return {
+                "signal": stop_signal["signal"],
+                "price": price,
+                "symbol": symbol,
+                "reason": stop_signal["reason"],
+            }
 
         qty = 0
         if position is not None:

--- a/src/spectr/strategies/macd_oscillator.py
+++ b/src/spectr/strategies/macd_oscillator.py
@@ -2,7 +2,12 @@ import logging
 from typing import Optional
 
 import pandas as pd
-from .trading_strategy import TradingStrategy, IndicatorSpec, get_order_sides
+from .trading_strategy import (
+    TradingStrategy,
+    IndicatorSpec,
+    get_order_sides,
+    check_stop_levels,
+)
 
 log = logging.getLogger(__name__)
 
@@ -52,6 +57,15 @@ class MACDOscillator(TradingStrategy):
         price = float(curr.get("close", 0))
         signal = None
         reason = None
+
+        stop_signal = check_stop_levels(price, position, stop_loss_pct, take_profit_pct)
+        if stop_signal:
+            return {
+                "signal": stop_signal["signal"],
+                "price": price,
+                "symbol": symbol,
+                "reason": stop_signal["reason"],
+            }
 
         in_position = False
         if position is not None:

--- a/src/spectr/strategies/trading_strategy.py
+++ b/src/spectr/strategies/trading_strategy.py
@@ -33,6 +33,59 @@ def get_order_sides(orders: Optional[Iterable]) -> set[str]:
     return sides
 
 
+def get_position_qty(position: Optional[object]) -> float:
+    """Return the numeric quantity for *position* or ``0.0``."""
+    if position is None:
+        return 0.0
+    qty = getattr(position, "qty", getattr(position, "size", 0))
+    try:
+        return float(qty)
+    except Exception:
+        return 0.0
+
+
+def get_entry_price(position: Optional[object]) -> Optional[float]:
+    """Return the entry price for *position*, if available."""
+    if position is None:
+        return None
+
+    for attr in ("avg_entry_price", "entry_price", "avg_price", "price"):
+        if hasattr(position, attr):
+            try:
+                return float(getattr(position, attr))
+            except Exception:
+                continue
+    return None
+
+
+def check_stop_levels(
+    price: float,
+    position: Optional[object],
+    stop_loss_pct: float,
+    take_profit_pct: float,
+) -> Optional[dict[str, str]]:
+    """Return an exit signal dict if stop levels are hit."""
+    qty = get_position_qty(position)
+    if qty == 0:
+        return None
+
+    entry_price = get_entry_price(position)
+    if entry_price is None:
+        return None
+
+    if qty > 0:
+        if price <= entry_price * (1 - stop_loss_pct):
+            return {"signal": "sell", "reason": "Stop loss"}
+        if price >= entry_price * (1 + take_profit_pct):
+            return {"signal": "sell", "reason": "Take profit"}
+    elif qty < 0:
+        if price >= entry_price * (1 + stop_loss_pct):
+            return {"signal": "buy", "reason": "Stop loss"}
+        if price <= entry_price * (1 - take_profit_pct):
+            return {"signal": "buy", "reason": "Take profit"}
+    return None
+
+
 @dataclass
 class IndicatorSpec:
     """Specification for an indicator used by a strategy."""
@@ -84,7 +137,7 @@ class TradingStrategy(bt.Strategy):
                     "price": self.datas[0].close[0],
                 }
             )
-            self.entry_price = self.datas[0].close[0]
+            self.entry_price = None
             return
 
         if signal and signal.get("signal") == "buy":
@@ -97,7 +150,7 @@ class TradingStrategy(bt.Strategy):
                     "price": self.datas[0].close[0],
                 }
             )
-            self.entry_price = None
+            self.entry_price = self.datas[0].close[0]
 
     def next(self) -> None:
         lookback = self.get_lookback()

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -235,6 +235,55 @@ def test_dual_thrust_signals():
     assert sig and sig["signal"] == "sell"
 
 
+def test_stop_loss_and_take_profit():
+    idx = pd.date_range("2021-01-01", periods=2, freq="D")
+    df = pd.DataFrame(
+        {
+            "open": [100, 99],
+            "high": [100, 99],
+            "low": [100, 99],
+            "close": [100, 99],
+            "volume": [1, 1],
+        },
+        index=idx,
+    )
+    sig = CustomStrategy.detect_signals(
+        df,
+        "TEST",
+        position=SimpleNamespace(qty=1, avg_entry_price=100),
+        stop_loss_pct=0.01,
+        take_profit_pct=0.05,
+        bb_period=20,
+        bb_dev=2,
+        macd_thresh=0.005,
+        is_backtest=False,
+    )
+    assert sig and sig["signal"] == "sell" and "Stop loss" in sig["reason"]
+
+    df = pd.DataFrame(
+        {
+            "open": [100, 106],
+            "high": [100, 106],
+            "low": [100, 106],
+            "close": [100, 106],
+            "volume": [1, 1],
+        },
+        index=idx,
+    )
+    sig = CustomStrategy.detect_signals(
+        df,
+        "TEST",
+        position=SimpleNamespace(qty=1, avg_entry_price=100),
+        stop_loss_pct=0.01,
+        take_profit_pct=0.05,
+        bb_period=20,
+        bb_dev=2,
+        macd_thresh=0.005,
+        is_backtest=False,
+    )
+    assert sig and sig["signal"] == "sell" and "Take profit" in sig["reason"]
+
+
 def test_indicator_specs():
     assert any(spec.name == "MACD" for spec in CustomStrategy.get_indicators())
 


### PR DESCRIPTION
## Summary
- add helpers for stop loss/take profit logic
- support stop levels in all strategies
- track entry price correctly
- test stop loss and take profit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877ee0c9660832e809ffeb697bd0b8e