### PR TITLE
Fix overlay visibility and reason lookup

### DIFF
--- a/src/spectr/default.tcss
+++ b/src/spectr/default.tcss
@@ -116,6 +116,7 @@ TickerInputDialog {
 #overlay-text {
     height: 1;
     dock: top;
+    layer: overlay;
     background: black;
     text-style: bold;
     content-align-horizontal: center;

--- a/src/spectr/views/portfolio_screen.py
+++ b/src/spectr/views/portfolio_screen.py
@@ -510,7 +510,10 @@ class PortfolioScreen(Screen):
         """Return the cached signal reason for an order, if available."""
         if not order_id:
             return ""
-        for rec in reversed(self.app.strategy_signals):
+        app = getattr(self, "app", None)
+        if app is None or not hasattr(app, "strategy_signals"):
+            return ""
+        for rec in reversed(app.strategy_signals):
             rec_id = rec.get("order_id")
             if rec_id is not None and str(rec_id) == str(order_id):
                 return str(rec.get("reason", ""))


### PR DESCRIPTION
## Summary
- ensure the status bar overlay stays visible when opening portfolio screen
- avoid crashes when looking up order reasons before the screen is mounted

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68783e7ff468832ea27cb045ff801012