### PR TITLE
Prevent duplicate orders

### DIFF
--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -867,6 +867,13 @@ class SpectrApp(App):
     ):
         if self._is_splash_active():
             return
+        if BROKER_API.has_pending_order(symbol):
+            log.warning(f"Pending order for {symbol}; dialog not opened")
+            if hasattr(self, "overlay") and self.overlay:
+                self.overlay.flash_message(
+                    f"Pending order for {symbol}", style="bold yellow", duration=5.0
+                )
+            return
         order_type, limit_price = broker_tools.prepare_order_details(
             symbol, side, BROKER_API
         )
@@ -998,6 +1005,15 @@ class SpectrApp(App):
             f"Placing {msg.side} {msg.qty} {msg.symbol} @ ${msg.price:.2f} "
             f"(total ${msg.total:,.2f})"
         )
+        if BROKER_API.has_pending_order(msg.symbol):
+            log.warning(f"Pending order for {msg.symbol}; not submitting")
+            if hasattr(self, "overlay") and self.overlay:
+                self.overlay.flash_message(
+                    f"Pending order for {msg.symbol}",
+                    style="bold yellow",
+                    duration=5.0,
+                )
+            return
         try:
             order = broker_tools.submit_order(
                 BROKER_API,

--- a/tests/test_pending_order.py
+++ b/tests/test_pending_order.py
@@ -1,0 +1,46 @@
+import asyncio
+from types import SimpleNamespace
+import spectr.spectr as appmod
+from spectr.spectr import SpectrApp
+from spectr.views.order_dialog import OrderDialog
+from spectr.fetch.broker_interface import OrderSide, OrderType
+
+
+def test_on_order_dialog_submit_skips_when_pending(monkeypatch):
+    calls = []
+    overlay = SimpleNamespace(flash_message=lambda *a, **k: calls.append("flash"))
+    app = SimpleNamespace(
+        trade_amount=0.0,
+        auto_trading_enabled=True,
+        voice_agent=SimpleNamespace(say=lambda *a, **k: None),
+        strategy_signals=[],
+        df_cache={},
+        ticker_symbols=["AAA"],
+        active_symbol_index=0,
+        overlay=overlay,
+    )
+
+    monkeypatch.setattr(
+        appmod, "BROKER_API", SimpleNamespace(has_pending_order=lambda s: True)
+    )
+    monkeypatch.setattr(
+        appmod.broker_tools, "submit_order", lambda *a, **k: calls.append("submit")
+    )
+    monkeypatch.setattr(
+        appmod.cache, "attach_order_to_last_signal", lambda *a, **k: None
+    )
+
+    msg = OrderDialog.Submit(
+        sender=None,
+        symbol="AAA",
+        side=OrderSide.BUY,
+        price=10.0,
+        qty=1.0,
+        total=10.0,
+        order_type=OrderType.MARKET,
+        limit_price=None,
+    )
+
+    asyncio.run(SpectrApp.on_order_dialog_submit(app, msg))
+
+    assert calls == ["flash"]


### PR DESCRIPTION
## Summary
- prevent opening an order dialog when a symbol has a pending order
- skip submitting orders if one is already pending
- test for avoiding duplicate order submission

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879598db6c8832eacae66f56a82c13a