### PR TITLE
Fix order cancellation with full UUID

### DIFF
--- a/src/spectr/views/portfolio_screen.py
+++ b/src/spectr/views/portfolio_screen.py
@@ -489,7 +489,8 @@ class PortfolioScreen(Screen):
         if event.data_table.id != "orders-table":
             return
 
-        row_id = str(event.cell_key.row_key)
+        row_key = event.cell_key.row_key
+        row_id = str(getattr(row_key, "value", row_key))
 
         if event.cell_key.column_key == self._cancel_col:
             cell_val = event.value


### PR DESCRIPTION
## Summary
- use the DataTable row key's `value` when cancelling an order

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68795a09ac74832e8d31478dd4d12c4c