### PR TITLE
Fix overlay removal and mounting

### DIFF
--- a/src/spectr/views/portfolio_screen.py
+++ b/src/spectr/views/portfolio_screen.py
@@ -275,7 +275,7 @@ class PortfolioScreen(Screen):
         overlay = getattr(self.app, "overlay", None)
         if isinstance(overlay, Widget):
             if overlay.parent:
-                overlay.remove()
+                await overlay.remove()
             await self.mount(overlay, before=0)
         # Fetch account data in the background so the dialog appears immediately
         asyncio.create_task(self._reload_account_data())
@@ -305,7 +305,7 @@ class PortfolioScreen(Screen):
         overlay = getattr(self.app, "overlay", None)
         if isinstance(overlay, Widget):
             if overlay.parent:
-                overlay.remove()
+                await overlay.remove()
             await self.app.mount(overlay, before=0)
 
     async def _reload_account_data(self):

--- a/src/spectr/views/strategy_screen.py
+++ b/src/spectr/views/strategy_screen.py
@@ -116,7 +116,7 @@ class StrategyScreen(Screen):
         overlay = getattr(self.app, "overlay", None)
         if isinstance(overlay, Widget):
             if overlay.parent:
-                overlay.remove()
+                await overlay.remove()
             await self.mount(overlay, before=0)
 
     async def on_select_changed(self, event: Select.Changed):
@@ -221,5 +221,5 @@ class StrategyScreen(Screen):
         overlay = getattr(self.app, "overlay", None)
         if isinstance(overlay, Widget):
             if overlay.parent:
-                overlay.remove()
+                await overlay.remove()
             await self.app.mount(overlay, before=0)

--- a/src/spectr/views/ticker_input_dialog.py
+++ b/src/spectr/views/ticker_input_dialog.py
@@ -92,7 +92,7 @@ class TickerInputDialog(ModalScreen):
         overlay = getattr(self.app, "overlay", None)
         if isinstance(overlay, Widget):
             if overlay.parent:
-                overlay.remove()
+                await overlay.remove()
             await self.mount(overlay, before=0)
         input_widget = self.query_one("#ticker-input", Input)
         if hasattr(self.app, "ticker_symbols"):
@@ -144,7 +144,7 @@ class TickerInputDialog(ModalScreen):
         overlay = getattr(self.app, "overlay", None)
         if isinstance(overlay, Widget):
             if overlay.parent:
-                overlay.remove()
+                await overlay.remove()
             await self.app.mount(overlay, before=0)
 
     def on_data_table_row_selected(


### PR DESCRIPTION
## Summary
- fix `remove()` calls to await re-mounting overlay widgets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aa0db05e0832e950e82e8e3089b75