### PR TITLE
Fix extended-hours order TIF

### DIFF
--- a/src/spectr/fetch/alpaca.py
+++ b/src/spectr/fetch/alpaca.py
@@ -420,7 +420,9 @@ class AlpacaInterface(BrokerInterface):
         try:
             tc = self.get_api()
             tif = TimeInForce.GTC
-            if (
+            if extended_hours and not is_crypto_symbol(symbol):
+                tif = TimeInForce.DAY
+            elif (
                 quantity is not None
                 and not float(quantity).is_integer()
                 and not is_crypto_symbol(symbol)

--- a/tests/test_alpaca_order_tif.py
+++ b/tests/test_alpaca_order_tif.py
@@ -1,0 +1,40 @@
+import types
+from spectr.fetch.alpaca import AlpacaInterface, OrderSide, OrderType, TimeInForce
+import spectr.fetch.alpaca as alpaca
+
+
+def test_alpaca_afterhours_time_in_force(monkeypatch):
+    captured = {}
+
+    class DummyTradingClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        def submit_order(self, req):
+            captured['tif'] = req.time_in_force
+            captured['extended_hours'] = getattr(req, 'extended_hours', None)
+            captured['req_type'] = type(req)
+            return 'ok'
+
+    class DummyLimitOrderRequest:
+        def __init__(self, **kwargs):
+            self.time_in_force = kwargs['time_in_force']
+            self.extended_hours = kwargs.get('extended_hours')
+
+    monkeypatch.setattr(alpaca, 'TradingClient', DummyTradingClient)
+    monkeypatch.setattr(alpaca, 'LimitOrderRequest', DummyLimitOrderRequest)
+    monkeypatch.setattr(alpaca, 'MarketOrderRequest', DummyLimitOrderRequest)
+
+    iface = AlpacaInterface()
+    iface.submit_order(
+        symbol='AAPL',
+        side=OrderSide.BUY,
+        type=OrderType.LIMIT,
+        quantity=1,
+        limit_price=10.0,
+        market_price=None,
+        extended_hours=True,
+    )
+
+    assert captured['tif'] == TimeInForce.DAY
+    assert captured['extended_hours'] is True


### PR DESCRIPTION
## Summary
- ensure extended-hours orders are submitted with `TimeInForce.DAY`
- add regression test for Alpaca interface time-in-force handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ab2234c38832e9175284b270c966e