### PR TITLE
Fix limit order reasons

### DIFF
--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -617,6 +617,7 @@ class SpectrApp(App):
                             _sym.upper(),
                             side.name.lower(),
                             order,
+                            reason=_reason,
                         )
             elif symbol == self.ticker_symbols[self.active_symbol_index]:
                 if not self.is_backtest:
@@ -1032,6 +1033,7 @@ class SpectrApp(App):
                 msg.symbol.upper(),
                 msg.side.name.lower(),
                 order,
+                reason=None,
             )
         except Exception as e:
             log.error(e)

--- a/tests/test_attach_order_reason.py
+++ b/tests/test_attach_order_reason.py
@@ -1,0 +1,18 @@
+from types import SimpleNamespace
+from spectr import cache
+
+
+def test_attach_creates_record_with_reason(tmp_path):
+    path = tmp_path / "cache.json"
+    signals = []
+    order = SimpleNamespace(id="1", status="pending")
+    cache.attach_order_to_last_signal(
+        signals, "AAPL", "buy", order, reason="test", path=path
+    )
+
+    loaded = cache.load_strategy_cache(path=path)
+    assert len(loaded) == 1
+    rec = loaded[0]
+    assert rec["reason"] == "test"
+    assert rec["order_id"] == "1"
+    assert rec["order_status"] == "pending"


### PR DESCRIPTION
## Summary
- record order reasons even when no matching signal record exists
- pass reason to `attach_order_to_last_signal`
- test that order reason is persisted

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ac5b23048832e8a38be911c02a337