### PR TITLE
Add strategy selection to backtest dialog

### DIFF
--- a/src/spectr/default.tcss
+++ b/src/spectr/default.tcss
@@ -114,6 +114,33 @@ TickerInputDialog {
     overflow: auto;
 }
 
+/* ------- Backtest Input Dialog ------- */
+
+BacktestInputDialog {
+    align: center middle;
+}
+
+#backtest-input-body {
+    width: 66%;
+    border: solid green;
+    padding: 1 2;
+    content-align-horizontal: center;
+    background: #1a1a1a;
+}
+
+#backtest-input-body Input,
+#backtest-input-body Select {
+    background: #262626;
+    color: #00ff55;
+}
+
+#backtest-buttons-row {
+    width: 100%;
+    content-align-horizontal: center;
+    align: center middle;
+    margin: 1 0;
+}
+
 
 
 /* ------- Status Bar Overlay ------- */
@@ -335,7 +362,7 @@ BacktestResultScreen {
 }
 
 #backtest-result-container {
-    width: 80%;
+    width: 66%;
     height: 42;
     background: #1a1a1a;
     border: solid green;

--- a/src/spectr/views/backtest_input_dialog.py
+++ b/src/spectr/views/backtest_input_dialog.py
@@ -1,23 +1,49 @@
 from datetime import date, timedelta
 
 from textual.screen import ModalScreen
-from textual.widgets import Input, Button, Label, Static
+from textual.widgets import Input, Button, Label, Static, Select
 from textual.app import ComposeResult
+from textual.containers import Vertical, Horizontal
 import asyncio
 import inspect
 
+
 class BacktestInputDialog(ModalScreen):
-    """Modal form: symbol, from/to dates, and starting balance."""
+    """Modal form for selecting symbol, strategy and date range."""
+
     CSS = """
     BacktestInputDialog {
         align: center middle;
-        width: 40%;
+    }
+
+    #backtest-input-body {
+        width: 66%;
+        border: solid green;
+        padding: 1 2;
+        content-align-horizontal: center;
+        background: #1a1a1a;
+    }
+
+    #backtest-input-body Input,
+    #backtest-input-body Select {
+        background: #262626;
+        color: #00ff55;
     }
     """
 
-    def __init__(self, callback, default_symbol: str = ""):
+    def __init__(
+        self,
+        callback,
+        default_symbol: str = "",
+        strategies=None,
+        current_strategy: str | None = None,
+    ):
         self._callback = callback
         self._default_symbol = default_symbol
+        self._strategies = strategies or []
+        self._current_strategy = current_strategy or (
+            self._strategies[0] if self._strategies else ""
+        )
 
         # --- Figure out last week’s Monday-Friday ---
         today = date.today()  # uses local timezone
@@ -31,30 +57,43 @@ class BacktestInputDialog(ModalScreen):
         super().__init__()
 
     def compose(self) -> ComposeResult:
-        yield Static("Back-test Parameters", classes="title")
-        yield Input(
-            value=self._default_symbol,  # pre-populated
-            placeholder="Symbol (e.g. NVDA)",
-            id="symbol",
+        yield Vertical(
+            Static("Back-test Parameters", classes="title"),
+            Input(
+                value=self._default_symbol,  # pre-populated
+                placeholder="Symbol (e.g. NVDA)",
+                id="symbol",
+            ),
+            Select(
+                id="strategy-select",
+                prompt="",
+                value=self._current_strategy,
+                options=[(s, s) for s in self._strategies],
+            ),
+            Input(
+                value=self._default_from,
+                placeholder="From date YYYY-MM-DD",
+                id="from",
+            ),
+            Input(
+                value=self._default_to,
+                placeholder="To date YYYY-MM-DD",
+                id="to",
+            ),
+            Input(value="10000", placeholder="Starting balance $", id="cash"),
+            Horizontal(
+                Button("Run", id="run", variant="success"),
+                Button("Cancel", id="cancel", variant="error"),
+                id="backtest-buttons-row",
+            ),
+            id="backtest-input-body",
         )
-        yield Input(
-            value=self._default_from,
-            placeholder="From date YYYY-MM-DD",
-            id="from",
-        )
-        yield Input(
-            value=self._default_to,
-            placeholder="To date YYYY-MM-DD",
-            id="to",
-        )
-        yield Input(value="10000", placeholder="Starting balance $", id="cash")
-        yield Button("Run", id="run", variant="success")
-        yield Button("Cancel", id="cancel", variant="error")
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "run":
             vals = {
                 "symbol": self.query_one("#symbol", Input).value.strip().upper(),
+                "strategy": self.query_one("#strategy-select", Select).value,
                 "from": self.query_one("#from", Input).value.strip(),
                 "to": self.query_one("#to", Input).value.strip(),
                 "cash": self.query_one("#cash", Input).value.strip(),

--- a/src/spectr/views/strategy_screen.py
+++ b/src/spectr/views/strategy_screen.py
@@ -81,13 +81,22 @@ class StrategyScreen(Screen):
             value=self.current,
             options=[(name, name) for name in self.strategy_names],
         )
-        self.code_widget = TextArea(
-            self.code_str,
-            language="python",
-            theme="monokai",
-            show_line_numbers=True,
-            id="strategy-code-content",
-        )
+        try:
+            self.code_widget = TextArea(
+                self.code_str,
+                language="python",
+                theme="monokai",
+                show_line_numbers=True,
+                id="strategy-code-content",
+            )
+        except Exception:
+            self.code_widget = TextArea(
+                self.code_str,
+                language=None,
+                theme="monokai",
+                show_line_numbers=True,
+                id="strategy-code-content",
+            )
         toolbar = Horizontal(
             Button("Undo", id="strategy-undo"),
             Button("Redo", id="strategy-redo"),
@@ -127,7 +136,10 @@ class StrategyScreen(Screen):
             self.file_path = self._get_strategy_file(self.current)
             self.code_str = self.file_path.read_text(encoding="utf-8")
             self.code_widget.text = self.code_str
-            self.code_widget.language = "python"
+            try:
+                self.code_widget.language = "python"
+            except Exception:
+                self.code_widget.language = None
             event.select.blur()
 
     async def on_button_pressed(self, event: Button.Pressed) -> None:
@@ -224,4 +236,5 @@ class StrategyScreen(Screen):
         if isinstance(overlay, Widget):
             if overlay.parent:
                 await overlay.remove()
-            await self.app.mount(overlay, before=0)
+            if getattr(self.app, "_screen_stack", None):
+                await self.app.mount(overlay, before=0)


### PR DESCRIPTION
## Summary
- tweak BacktestResult screen width and add styles for BacktestInputDialog
- add strategy dropdown to backtest dialog and pass chosen strategy to backtest
- fall back when syntax highlighting isn't available

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ef213a5cc832eadda34c6cc60b7b8