### PR TITLE
Fix hidden labels on backtest dialog

### DIFF
--- a/src/spectr/default.tcss
+++ b/src/spectr/default.tcss
@@ -133,6 +133,17 @@ BacktestInputDialog {
     background: #262626;
     color: #00ff55;
 }
+#backtest-input-body Label {
+    height: 3;
+    text-align: center;
+    padding: 1 0;
+}
+
+#backtest-title {
+    text-align: center;
+    padding: 0 1;
+    height: 2;
+}
 
 #backtest-buttons-row {
     width: 100%;

--- a/src/spectr/views/backtest_input_dialog.py
+++ b/src/spectr/views/backtest_input_dialog.py
@@ -11,37 +11,6 @@ import inspect
 class BacktestInputDialog(ModalScreen):
     """Modal form for selecting symbol, strategy and date range."""
 
-    CSS = """
-    BacktestInputDialog {
-        align: center middle;
-    }
-
-    #backtest-input-body {
-        width: 66%;
-        border: solid green;
-        padding: 1 2;
-        content-align-horizontal: center;
-        background: #1a1a1a;
-    }
-
-    #backtest-input-body Input,
-    #backtest-input-body Select {
-        background: #262626;
-        color: #00ff55;
-    }
-    #backtest-input-body Label {
-        height: 3;
-        text-align: center;
-        padding: 1 0;
-    }
-
-    #backtest-title {
-        text-align: center;
-        padding: 0 1;
-        height: 2;
-    }
-    """
-
     def __init__(
         self,
         callback,

--- a/src/spectr/views/backtest_input_dialog.py
+++ b/src/spectr/views/backtest_input_dialog.py
@@ -29,6 +29,17 @@ class BacktestInputDialog(ModalScreen):
         background: #262626;
         color: #00ff55;
     }
+    #backtest-input-body Label {
+        height: 3;
+        text-align: center;
+        padding: 1 0;
+    }
+
+    #backtest-title {
+        text-align: center;
+        padding: 0 1;
+        height: 2;
+    }
     """
 
     def __init__(
@@ -58,28 +69,33 @@ class BacktestInputDialog(ModalScreen):
 
     def compose(self) -> ComposeResult:
         yield Vertical(
-            Static("Back-test Parameters", classes="title"),
+            Static("Back-test Parameters", id="backtest-title", classes="title"),
+            Label("Symbol:"),
             Input(
-                value=self._default_symbol,  # pre-populated
+                value=self._default_symbol,
                 placeholder="Symbol (e.g. NVDA)",
                 id="symbol",
             ),
+            Label("Strategy:"),
             Select(
                 id="strategy-select",
                 prompt="",
                 value=self._current_strategy,
                 options=[(s, s) for s in self._strategies],
             ),
+            Label("From:"),
             Input(
                 value=self._default_from,
                 placeholder="From date YYYY-MM-DD",
                 id="from",
             ),
+            Label("To:"),
             Input(
                 value=self._default_to,
                 placeholder="To date YYYY-MM-DD",
                 id="to",
             ),
+            Label("Starting Cash:"),
             Input(value="10000", placeholder="Starting balance $", id="cash"),
             Horizontal(
                 Button("Run", id="run", variant="success"),


### PR DESCRIPTION
## Summary
- show field labels on the backtest input dialog
- style labels and title in CSS

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68806d224104832eae22d70ea3ea539c