### PR TITLE
Add escape key close for backtest dialog

### DIFF
--- a/src/spectr/views/backtest_input_dialog.py
+++ b/src/spectr/views/backtest_input_dialog.py
@@ -11,6 +11,10 @@ import inspect
 class BacktestInputDialog(ModalScreen):
     """Modal form for selecting symbol, strategy and date range."""
 
+    BINDINGS = [
+        ("escape", "app.pop_screen", "Cancel"),
+    ]
+
     def __init__(
         self,
         callback,

--- a/tests/test_backtest_input_dialog.py
+++ b/tests/test_backtest_input_dialog.py
@@ -1,0 +1,24 @@
+import asyncio
+from textual.app import App
+
+from spectr.views.backtest_input_dialog import BacktestInputDialog
+
+
+class DialogApp(App):
+    async def on_mount(self) -> None:
+        self.dlg = BacktestInputDialog(
+            lambda *a, **k: None,
+            default_symbol="TEST",
+            strategies=["S"],
+            current_strategy="S",
+        )
+        await self.push_screen(self.dlg)
+
+
+def test_backtest_dialog_escape_dismisses():
+    async def run() -> None:
+        async with DialogApp().run_test() as pilot:
+            await pilot.press("escape")
+            assert not isinstance(pilot.app.screen, BacktestInputDialog)
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- enable Escape key to dismiss BacktestInputDialog
- test closing backtest dialog using Escape

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68808692f438832eae972c3711ca72a5