### PR TITLE
Fix cancel button crash for string order statuses

### DIFF
--- a/src/spectr/views/portfolio_screen.py
+++ b/src/spectr/views/portfolio_screen.py
@@ -218,7 +218,13 @@ class PortfolioScreen(Screen):
                     order.order_type,
                     reason,
                     order.status,
-                    "Cancel" if self._is_cancelable(order.status.name) else "",
+                    (
+                        "Cancel"
+                        if self._is_cancelable(
+                            getattr(order.status, "name", order.status)
+                        )
+                        else ""
+                    ),
                     short_id,
                     key=order_id,
                 )
@@ -419,7 +425,13 @@ class PortfolioScreen(Screen):
                     order.order_type,
                     reason,
                     order.status,
-                    "Cancel" if self._is_cancelable(order.status.name) else "",
+                    (
+                        "Cancel"
+                        if self._is_cancelable(
+                            getattr(order.status, "name", order.status)
+                        )
+                        else ""
+                    ),
                     short_id,
                     key=order_id,
                 )


### PR DESCRIPTION
## Summary
- handle order status objects without `.name`

## Testing
- `black src/spectr/views/portfolio_screen.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881e5c621e4832eb4cf8874475a8661