### PR TITLE
Fix pending order detection for cancelled Alpaca orders

### DIFF
--- a/src/spectr/fetch/alpaca.py
+++ b/src/spectr/fetch/alpaca.py
@@ -110,23 +110,25 @@ class AlpacaInterface(BrokerInterface):
         """True if there is any order for ``symbol`` that is not closed."""
         try:
             tc = self.get_api()
+            # Only fetch open orders to avoid closed/cancelled ones.
             req = GetOrdersRequest(
-                status=QueryOrderStatus.ALL, symbols=[symbol.upper()]
+                status=QueryOrderStatus.OPEN, symbols=[symbol.upper()]
             )
             orders = tc.get_orders(req)
+
             for o in orders:
                 status = getattr(o, "status", "")
                 if hasattr(status, "value"):
                     status = status.value
                 status = str(status).lower()
                 if status not in {
-                    "filled",
                     "canceled",
                     "cancelled",
                     "expired",
                     "rejected",
                     "done_for_day",
                     "replaced",
+                    "filled",
                 }:
                     return True
             return False

--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -605,7 +605,7 @@ class SpectrApp(App):
                             self.voice_agent.say(
                                 f"Ignoring {_sig.capitalize()} signal for {_sym}, pending order already exists."
                             )
-                            return
+                            continue
 
                         self.signal_detected.remove(signal)
                         order = broker_tools.submit_order(

--- a/tests/test_has_pending_order.py
+++ b/tests/test_has_pending_order.py
@@ -1,0 +1,23 @@
+import types
+from spectr.fetch.alpaca import AlpacaInterface
+
+
+class DummyTradingClient:
+    def __init__(self, statuses):
+        self.statuses = statuses
+
+    def get_orders(self, req):
+        return [types.SimpleNamespace(status=s) for s in self.statuses]
+
+
+def test_has_pending_order_filters_cancelled(monkeypatch):
+    iface = AlpacaInterface()
+    monkeypatch.setattr(
+        iface, "get_api", lambda: DummyTradingClient(["canceled", "cancelled"])
+    )
+    assert iface.has_pending_order("AAA") is False
+
+    monkeypatch.setattr(
+        iface, "get_api", lambda: DummyTradingClient(["new", "canceled"])
+    )
+    assert iface.has_pending_order("AAA") is True

--- a/tests/test_process_updates_pending.py
+++ b/tests/test_process_updates_pending.py
@@ -1,0 +1,44 @@
+import asyncio
+import queue
+from types import SimpleNamespace
+import spectr.spectr as appmod
+from spectr.spectr import SpectrApp
+
+
+async def _run_updates(app):
+    await SpectrApp._process_updates(app)
+
+
+def test_process_updates_skips_and_continues(monkeypatch):
+    q = queue.Queue()
+    q.put("AAA")
+    q.put(None)  # sentinel for exit
+    calls = []
+
+    app = SimpleNamespace(
+        _update_queue=q,
+        signal_detected=[("AAA", 10.0, "sell", "r")],
+        ticker_symbols=["AAA"],
+        active_symbol_index=0,
+        auto_trading_enabled=True,
+        afterhours_enabled=True,
+        trade_amount=0.0,
+        voice_agent=SimpleNamespace(say=lambda *a, **k: None),
+        screen_stack=[],
+        strategy_signals=[],
+    )
+
+    monkeypatch.setattr(
+        appmod,
+        "BROKER_API",
+        SimpleNamespace(has_pending_order=lambda s: True),
+    )
+    monkeypatch.setattr(
+        appmod.broker_tools, "submit_order", lambda *a, **k: calls.append(True)
+    )
+
+    asyncio.run(_run_updates(app))
+
+    assert calls == []
+    assert app.signal_detected == []
+    assert q.empty()


### PR DESCRIPTION
## Summary
- check only open Alpaca orders when determining if a symbol has a pending order
- add regression test verifying cancelled orders are ignored

## Testing
- `pytest tests/test_has_pending_order.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688264c29668832e8f69d297f8977fba