### PR TITLE
Fix backtest position checks

### DIFF
--- a/src/spectr/strategies/awesome_oscillator.py
+++ b/src/spectr/strategies/awesome_oscillator.py
@@ -7,6 +7,7 @@ from .trading_strategy import (
     IndicatorSpec,
     get_order_sides,
     check_stop_levels,
+    get_position_qty,
 )
 
 log = logging.getLogger(__name__)
@@ -70,13 +71,8 @@ class AwesomeOscillator(TradingStrategy):
                 "reason": stop_signal["reason"],
             }
 
-        in_position = False
-        if position is not None:
-            qty = getattr(position, "qty", getattr(position, "size", 0))
-            try:
-                in_position = float(qty) != 0
-            except Exception:
-                in_position = bool(qty)
+        qty = get_position_qty(position)
+        in_position = qty != 0
 
         if not in_position:
             if (

--- a/src/spectr/strategies/dual_thrust.py
+++ b/src/spectr/strategies/dual_thrust.py
@@ -9,6 +9,7 @@ from .trading_strategy import (
     IndicatorSpec,
     get_order_sides,
     check_stop_levels,
+    get_position_qty,
 )
 
 log = logging.getLogger(__name__)
@@ -92,13 +93,7 @@ class DualThrust(TradingStrategy):
                 "reason": stop_signal["reason"],
             }
 
-        qty = 0
-        if position is not None:
-            qty = getattr(position, "qty", getattr(position, "size", 0))
-            try:
-                qty = float(qty)
-            except Exception:
-                qty = 0.0
+        qty = get_position_qty(position)
         in_pos = qty != 0
         pos_dir = 1 if qty > 0 else -1 if qty < 0 else 0
 

--- a/src/spectr/strategies/macd_oscillator.py
+++ b/src/spectr/strategies/macd_oscillator.py
@@ -7,6 +7,7 @@ from .trading_strategy import (
     IndicatorSpec,
     get_order_sides,
     check_stop_levels,
+    get_position_qty,
 )
 
 log = logging.getLogger(__name__)
@@ -67,13 +68,8 @@ class MACDOscillator(TradingStrategy):
                 "reason": stop_signal["reason"],
             }
 
-        in_position = False
-        if position is not None:
-            qty = getattr(position, "qty", getattr(position, "size", 0))
-            try:
-                in_position = float(qty) != 0
-            except Exception:
-                in_position = bool(qty)
+        qty = get_position_qty(position)
+        in_position = qty != 0
 
         if not in_position:
             if curr_osc > 0 and prev_osc <= 0:

--- a/src/spectr/strategies/trading_strategy.py
+++ b/src/spectr/strategies/trading_strategy.py
@@ -148,8 +148,8 @@ class TradingStrategy(bt.Strategy):
             self.entry_price = None
             return
 
-        if signal and signal.get("signal") == "buy":
-            log.debug("BACKTEST: Exiting position")
+        if signal and signal.get("signal") == "buy" and not qty:
+            log.debug(f"BACKTEST: Buy signal detected: {signal['reason']}")
             self.buy()
             self.buy_signals.append(
                 {


### PR DESCRIPTION
## Summary
- standardize position checks in strategies using get_position_qty
- avoid duplicate buys during backtests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68828e1127d4832ea7400694d603a214