### PR TITLE
Add backtest open order check

### DIFF
--- a/src/spectr/strategies/trading_strategy.py
+++ b/src/spectr/strategies/trading_strategy.py
@@ -168,7 +168,17 @@ class TradingStrategy(bt.Strategy):
         allowed = set(params) - {"self", "df", "symbol", "position", "orders"}
         filtered = {k: v for k, v in kwargs.items() if k in allowed}
 
+        open_orders = []
+        try:
+            open_orders = list(self.broker.get_orders_open(safe=True))
+        except Exception:  # pragma: no cover - unexpected
+            pass
+
         signal = self.detect_signals(
-            df, self.p.symbol, position=self.position, orders=None, **filtered
+            df,
+            self.p.symbol,
+            position=self.position,
+            orders=open_orders,
+            **filtered,
         )
         self.handle_signal(signal)

--- a/tests/test_backtest_run.py
+++ b/tests/test_backtest_run.py
@@ -1,0 +1,28 @@
+import pandas as pd
+from types import SimpleNamespace
+from spectr.backtest import run_backtest
+from spectr.strategies.macd_oscillator import MACDOscillator
+
+
+def test_backtest_buy_sell_counts_match():
+    idx = pd.date_range("2024-01-01", periods=9, freq="D")
+    vals = [1, 2, 1, 2, 1, 2, 1, 2, 1]
+    df = pd.DataFrame(
+        {
+            "open": vals,
+            "high": vals,
+            "low": vals,
+            "close": vals,
+            "volume": [1] * 9,
+        },
+        index=idx,
+    )
+    config = SimpleNamespace(
+        bb_period=20,
+        bb_dev=2,
+        macd_thresh=0.005,
+        fast_period=1,
+        slow_period=2,
+    )
+    result = run_backtest(df, "TEST", config, MACDOscillator)
+    assert len(result["buy_signals"]) == len(result["sell_signals"]) == 4


### PR DESCRIPTION
## Summary
- add unit test verifying run_backtest returns balanced buy/sell signals for a basic MACDOscillator dataset
- pass open orders from the broker to detect_signals so backtesting waits for pending orders to finish

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68829c8ed950832eb6c64ca54342c904