### PR TITLE
Add Bid Value column to holdings table

### DIFF
--- a/src/spectr/views/portfolio_screen.py
+++ b/src/spectr/views/portfolio_screen.py
@@ -108,6 +108,7 @@ class PortfolioScreen(Screen):
             "Qty",
             "Value",
             "Ask Value",
+            "Bid Value",
             "Avg Cost",
             "Profit",
         )
@@ -182,12 +183,13 @@ class PortfolioScreen(Screen):
                     pos.qty,
                     pos.market_value,
                     0.0,
+                    0.0,
                     cost,
                     profit,
                     key=pos.symbol,
                 )
         else:
-            self.holdings_table.add_row("Loading...", "", "", "", "", "")
+            self.holdings_table.add_row("Loading...", "", "", "", "", "", "")
 
         if self._has_cached_orders:
             self.cached_orders.sort(key=self._order_date, reverse=True)
@@ -382,7 +384,15 @@ class PortfolioScreen(Screen):
                 or quote.get("price")
                 or 0.0
             )
+            bid_price = (
+                quote.get("bid")
+                or quote.get("bid_price")
+                or quote.get("bidPrice")
+                or quote.get("price")
+                or 0.0
+            )
             ask_value = float(pos.qty) * float(ask_price) if ask_price else 0.0
+            bid_value = float(pos.qty) * float(bid_price) if bid_price else 0.0
 
             if pos.symbol not in existing_keys:
                 table.add_row(
@@ -390,6 +400,7 @@ class PortfolioScreen(Screen):
                     pos.qty,
                     pos.market_value,
                     ask_value,
+                    bid_value,
                     cost,
                     profit,
                     key=pos.symbol,
@@ -400,8 +411,9 @@ class PortfolioScreen(Screen):
                     pos.symbol, self.holdings_table_columns[2], pos.market_value
                 )
                 table.update_cell(pos.symbol, self.holdings_table_columns[3], ask_value)
-                table.update_cell(pos.symbol, self.holdings_table_columns[4], cost)
-                table.update_cell(pos.symbol, self.holdings_table_columns[5], profit)
+                table.update_cell(pos.symbol, self.holdings_table_columns[4], bid_value)
+                table.update_cell(pos.symbol, self.holdings_table_columns[5], cost)
+                table.update_cell(pos.symbol, self.holdings_table_columns[6], profit)
                 row_index = table.get_row_index(pos.symbol)
                 table.refresh_row(row_index)
         table.scroll_home()

--- a/tests/test_holdings_ask_value.py
+++ b/tests/test_holdings_ask_value.py
@@ -33,10 +33,10 @@ class DummyApp(App):
         await self.push_screen(self.pscreen)
 
 
-def test_holdings_table_ask_value(monkeypatch):
+def test_holdings_table_bid_and_ask_value(monkeypatch):
     class DummyBroker:
         def fetch_quote(self, symbol: str):
-            return {"ask": 11.0}
+            return {"ask": 11.0, "bid": 9.0}
 
     monkeypatch.setattr(appmod, "BROKER_API", DummyBroker())
 
@@ -48,6 +48,8 @@ def test_holdings_table_ask_value(monkeypatch):
             await screen._reload_account_data()
             table = screen.query_one("#holdings-table", DataTable)
             ask_val = float(table.get_cell_at((0, 3)))
+            bid_val = float(table.get_cell_at((0, 4)))
             assert ask_val == 22.0
+            assert bid_val == 18.0
 
     asyncio.run(run())


### PR DESCRIPTION
## Summary
- show bid value alongside ask value for portfolio holdings
- test bid and ask value calculations on portfolio screen

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891039b4760832ebdb341b7cb67a789