### PR TITLE
Display dialogs as overlays

### DIFF
--- a/src/spectr/default.tcss
+++ b/src/spectr/default.tcss
@@ -67,6 +67,7 @@ ScreenModal {
 
 TickerInputDialog {
     align: center middle;
+    background: transparent;
 }
 #ticker_input_dlg_body {
     width: 75%;
@@ -118,6 +119,7 @@ TickerInputDialog {
 
 BacktestInputDialog {
     align: center middle;
+    background: transparent;
 }
 
 #backtest-input-body {
@@ -302,6 +304,7 @@ SetupConfirmDialog {
 
 PortfolioScreen {
     align: center middle;
+    background: transparent;
 }
 
 #portfolio-screen {
@@ -371,6 +374,7 @@ PortfolioScreen {
 
 BacktestResultScreen {
     align: center middle;
+    background: transparent;
 }
 
 #backtest-result-container {
@@ -400,6 +404,7 @@ BacktestResultScreen {
 
 StrategyScreen {
     align: center middle;
+    background: transparent;
 }
 
 #strategy-screen {

--- a/src/spectr/views/backtest_result_screen.py
+++ b/src/spectr/views/backtest_result_screen.py
@@ -1,11 +1,11 @@
-from textual.screen import Screen
+from textual.screen import ModalScreen
 from textual.widgets import Static
 from textual.containers import Vertical
 
 from .graph_view import GraphView
 
 
-class BacktestResultScreen(Screen):
+class BacktestResultScreen(ModalScreen):
     """Screen displaying the back‑test graph and summary metrics."""
 
     BINDINGS = [

--- a/src/spectr/views/portfolio_screen.py
+++ b/src/spectr/views/portfolio_screen.py
@@ -5,7 +5,7 @@ from typing import Optional
 from types import SimpleNamespace
 import pandas as pd
 
-from textual.screen import Screen
+from textual.screen import ModalScreen
 from textual.widgets import Static, DataTable, Switch, Input, Button
 from textual.widget import Widget
 from textual.containers import Vertical, Container, Horizontal
@@ -24,7 +24,7 @@ from .setup_dialog import SetupDialog
 log = logging.getLogger(__name__)
 
 
-class PortfolioScreen(Screen):
+class PortfolioScreen(ModalScreen):
     """Modal screen that shows cash, invested value, and current holdings."""
 
     BINDINGS = [

--- a/src/spectr/views/strategy_screen.py
+++ b/src/spectr/views/strategy_screen.py
@@ -5,14 +5,14 @@ import pathlib
 import black
 
 from textual import events
-from textual.screen import Screen
+from textual.screen import ModalScreen
 from textual.widgets import DataTable, Static, Select, TextArea, Button
 from textual.widget import Widget
 from textual.containers import Vertical, VerticalScroll, Horizontal
 from textual.reactive import reactive
 
 
-class StrategyScreen(Screen):
+class StrategyScreen(ModalScreen):
     """Modal screen listing live strategy signals."""
 
     BINDINGS = [

--- a/tests/test_overlay_screens.py
+++ b/tests/test_overlay_screens.py
@@ -1,6 +1,11 @@
 import asyncio
+from types import SimpleNamespace
+
+import pandas as pd
 from textual.app import App
 
+from spectr.views.backtest_input_dialog import BacktestInputDialog
+from spectr.views.backtest_result_screen import BacktestResultScreen
 from spectr.views.strategy_screen import StrategyScreen
 from spectr.views.portfolio_screen import PortfolioScreen
 from spectr.views.ticker_input_dialog import TickerInputDialog
@@ -8,6 +13,8 @@ from spectr.views.top_overlay import TopOverlay
 
 
 class StrategyApp(App):
+    CSS_PATH = "../src/spectr/default.tcss"
+
     def compose(self):
         self.overlay = TopOverlay(id="overlay-text")
         yield self.overlay
@@ -20,12 +27,16 @@ class StrategyApp(App):
 def test_strategy_screen_has_overlay():
     async def run():
         async with StrategyApp().run_test() as pilot:
+            await pilot.pause()
             assert isinstance(pilot.app.overlay, TopOverlay)
+            assert pilot.app.scr.styles.background.a == 0
 
     asyncio.run(run())
 
 
 class PortfolioApp(App):
+    CSS_PATH = "../src/spectr/default.tcss"
+
     def compose(self):
         self.overlay = TopOverlay(id="overlay-text")
         yield self.overlay
@@ -47,12 +58,16 @@ class PortfolioApp(App):
 def test_portfolio_screen_has_overlay():
     async def run():
         async with PortfolioApp().run_test() as pilot:
+            await pilot.pause()
             assert isinstance(pilot.app.overlay, TopOverlay)
+            assert pilot.app.scr.styles.background.a == 0
 
     asyncio.run(run())
 
 
 class TickerApp(App):
+    CSS_PATH = "../src/spectr/default.tcss"
+
     def compose(self):
         self.overlay = TopOverlay(id="overlay-text")
         yield self.overlay
@@ -70,6 +85,64 @@ class TickerApp(App):
 def test_ticker_dialog_has_overlay():
     async def run():
         async with TickerApp().run_test() as pilot:
+            await pilot.pause()
             assert isinstance(pilot.app.overlay, TopOverlay)
+            assert pilot.app.scr.styles.background.a == 0
+
+    asyncio.run(run())
+
+
+class BacktestInputApp(App):
+    CSS_PATH = "../src/spectr/default.tcss"
+
+    def compose(self):
+        self.overlay = TopOverlay(id="overlay-text")
+        yield self.overlay
+
+    async def on_mount(self) -> None:
+        self.scr = BacktestInputDialog(
+            lambda *a, **k: None, strategies=["S"], current_strategy="S"
+        )
+        await self.push_screen(self.scr)
+
+
+def test_backtest_input_dialog_transparent():
+    async def run():
+        async with BacktestInputApp().run_test() as pilot:
+            await pilot.pause()
+            assert pilot.app.scr.styles.background.a == 0
+
+    asyncio.run(run())
+
+
+class BacktestResultApp(App):
+    CSS_PATH = "../src/spectr/default.tcss"
+
+    def compose(self):
+        self.overlay = TopOverlay(id="overlay-text")
+        yield self.overlay
+
+    async def on_mount(self) -> None:
+        df = pd.DataFrame()
+        args = SimpleNamespace(scale=1)
+        self.scr = BacktestResultScreen(
+            df,
+            args,
+            symbol="A",
+            start_date="2024-01-01",
+            end_date="2024-01-02",
+            start_value=0.0,
+            end_value=0.0,
+            num_buys=0,
+            num_sells=0,
+        )
+        await self.push_screen(self.scr)
+
+
+def test_backtest_result_screen_transparent():
+    async def run():
+        async with BacktestResultApp().run_test() as pilot:
+            await pilot.pause()
+            assert pilot.app.scr.styles.background.a == 0
 
     asyncio.run(run())


### PR DESCRIPTION
## Summary
- ensure portfolio, strategy, and backtest result screens inherit ModalScreen
- make ticker input, backtest input, portfolio, strategy, and backtest result dialogs transparent so underlying UI shows through
- add tests confirming each dialog screen renders with transparent background

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893aa0d935c832ea24a569514712dde