### PR TITLE
Make order dialog background transparent

### DIFF
--- a/src/spectr/default.tcss
+++ b/src/spectr/default.tcss
@@ -180,6 +180,7 @@ Static {
 
 OrderDialog {
     align: center middle;
+    background: transparent;
 }
 
 #dlg_body {


### PR DESCRIPTION
## Summary
- make OrderDialog's screen background transparent to match other dialogs

## Testing
- `black src/spectr/default.tcss` *(fails: Cannot parse for target version Python 3.13: 1:7: Screen {)*
- `pytest` *(fails: Interrupted: 34 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bbca7fa9c0832ebc5770a205ab41ea