### PR TITLE
Fix portfolio screen auto-trade shortcut

### DIFF
--- a/src/spectr/views/portfolio_screen.py
+++ b/src/spectr/views/portfolio_screen.py
@@ -584,6 +584,11 @@ class PortfolioScreen(ModalScreen):
             except Exception:
                 log.warning("Failed to copy order id to clipboard")
 
+    def on_key(self, event: events.Key) -> None:
+        if event.key == "ctrl+a":
+            event.stop()
+            self.app.action_arm_auto_trading()
+
     def _get_order_reason(self, order_id) -> str:
         """Return the cached signal reason for an order, if available."""
         if not order_id:

--- a/tests/test_portfolio_ctrl_a.py
+++ b/tests/test_portfolio_ctrl_a.py
@@ -1,0 +1,45 @@
+import asyncio
+from textual.app import App
+
+from spectr.views.portfolio_screen import PortfolioScreen
+
+
+class PortfolioApp(App):
+    def __init__(self):
+        super().__init__()
+        self.auto_trading_enabled = False
+        self.scr = None
+
+    def set_auto_trading(self, enabled: bool):
+        self.auto_trading_enabled = enabled
+        if self.scr is not None:
+            self.scr.auto_trading_enabled = enabled
+            self.scr.auto_switch.value = enabled
+
+    def action_arm_auto_trading(self):
+        self.set_auto_trading(not self.auto_trading_enabled)
+
+    async def on_mount(self) -> None:
+        self.scr = PortfolioScreen(
+            0.0,
+            0.0,
+            0.0,
+            [],
+            [],
+            lambda *a, **k: [],
+            lambda *a, **k: None,
+            False,
+            set_auto_trading_cb=self.set_auto_trading,
+        )
+        await self.push_screen(self.scr)
+
+
+def test_ctrl_a_toggles_auto_trading():
+    async def run() -> None:
+        async with PortfolioApp().run_test() as pilot:
+            pilot.app.scr.holdings_table.focus()
+            await pilot.press("ctrl+a")
+            assert pilot.app.auto_trading_enabled
+            assert pilot.app.scr.auto_switch.value
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- Ensure `Ctrl+A` toggles auto-trading on the portfolio screen by overriding key handler
- Add regression test verifying shortcut updates portfolio switch and state

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bbcaa848a0832e93cd9dd76c03645f