### PR TITLE
Recompute indicators during dataframe build

### DIFF
--- a/src/spectr/strategies/custom_strategy.py
+++ b/src/spectr/strategies/custom_strategy.py
@@ -2,8 +2,6 @@ import logging
 from typing import Optional
 
 import pandas as pd
-
-from . import metrics
 from .trading_strategy import (
     TradingStrategy,
     IndicatorSpec,
@@ -68,14 +66,11 @@ class CustomStrategy(TradingStrategy):
             "bb_mid",
             "macd_crossover",
         }
-        if (
-            not required_cols.issubset(df.columns)
-            or df.loc[:, list(required_cols)].isna().any().any()
+        if not required_cols.issubset(df.columns) or any(
+            pd.isna(curr.get(col)) for col in required_cols
         ):
-            df = metrics.analyze_indicators(
-                df,
-                CustomStrategy.get_indicators(),
-            )
+            log.warning("Required indicators missing; skipping signal")
+            return None
 
         macd_cross = curr.get("macd_crossover")
         above_bb = curr.get("close") > curr.get("bb_upper")

--- a/src/spectr/strategies/dual_thrust.py
+++ b/src/spectr/strategies/dual_thrust.py
@@ -141,7 +141,16 @@ class DualThrust(TradingStrategy):
             "volume": [self.datas[0].volume[-i] for i in reversed(range(lookback))],
         }
         index = [self.datas[0].datetime.datetime(-i) for i in reversed(range(lookback))]
-        return pd.DataFrame(data, index=index)
+        df = pd.DataFrame(data, index=index)
+        specs = self.get_indicators()
+        if specs:
+            try:
+                from . import metrics
+
+                df = metrics.analyze_indicators(df, specs)
+            except Exception:  # pragma: no cover - unexpected
+                log.warning("Failed to analyze indicators", exc_info=True)
+        return df
 
     def get_signal_args(self) -> dict:
         return {

--- a/src/spectr/strategies/trading_strategy.py
+++ b/src/spectr/strategies/trading_strategy.py
@@ -127,7 +127,17 @@ class TradingStrategy(bt.Strategy):
             "low": [self.datas[0].low[-i] for i in reversed(range(lookback))],
             "volume": [self.datas[0].volume[-i] for i in reversed(range(lookback))],
         }
-        return pd.DataFrame(data)
+        df = pd.DataFrame(data)
+
+        specs = self.get_indicators()
+        if specs:
+            try:
+                from . import metrics
+
+                df = metrics.analyze_indicators(df, specs)
+            except Exception:  # pragma: no cover - unexpected
+                log.warning("Failed to analyze indicators", exc_info=True)
+        return df
 
     def handle_signal(self, signal: Optional[dict]) -> None:
         if signal:


### PR DESCRIPTION
## Summary
- compute strategy indicators within `build_dataframe` so indicator columns persist
- remove redundant indicator analysis in `CustomStrategy`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc9c3ebedc832ebdc42e88e23cd0ff