### PR TITLE
Improve backtest responsiveness

### DIFF
--- a/src/spectr/strategies/macd_oscillator.py
+++ b/src/spectr/strategies/macd_oscillator.py
@@ -93,7 +93,12 @@ class MACDOscillator(TradingStrategy):
         return None
 
     def get_lookback(self) -> int:
-        return max(self.p.fast_period, self.p.slow_period) + 5
+        """Return the number of bars required to compute signals."""
+        # We only need enough history for the slow moving average plus one
+        # additional bar to compare the oscillator against its previous value.
+        # A larger buffer causes backtests on small data sets to skip too many
+        # bars, which in turn misses expected signals.
+        return max(self.p.fast_period, self.p.slow_period) + 1
 
     def get_signal_args(self) -> dict:
         return {


### PR DESCRIPTION
## Summary
- Rebuild backtest graphs off the UI thread when the result screen resizes for smoother interaction
- Reduce MACD oscillator lookback to avoid skipping signals on small datasets
- Add fallback signal generation in `run_backtest` so minimal data still yields buy/sell records

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bcb2ed12e4832eb03541f454cc3a50