### PR TITLE
Play success sound for orders without voice mode

### DIFF
--- a/src/spectr/broker_tools.py
+++ b/src/spectr/broker_tools.py
@@ -3,7 +3,7 @@ import math
 import traceback
 
 from .fetch.broker_interface import BrokerInterface, OrderSide, OrderType
-from .utils import is_market_open_now, is_crypto_symbol
+from .utils import is_market_open_now, is_crypto_symbol, play_sound
 
 log = logging.getLogger(__name__)
 
@@ -66,8 +66,7 @@ def submit_order(
     *,
     qty: float | None = None,
     voice_agent=None,
-    buy_sound_path: str | None = None,
-    sell_sound_path: str | None = None,
+    success_sound_path: str | None = None,
 ) -> object | None:
     """Prepare and submit an order, handling fractional reattempts.
 
@@ -103,8 +102,8 @@ def submit_order(
             market_price=price,
             extended_hours=extended_hours,
         )
-        # if buy_sound_path and sell_sound_path:
-            # play_sound(buy_sound_path if side == OrderSide.BUY else sell_sound_path)
+        if voice_agent is None and success_sound_path:
+            play_sound(success_sound_path)
         return order
     except Exception as e:  # noqa: BLE001
         err_msg = str(e)
@@ -144,10 +143,8 @@ def submit_order(
                         market_price=price,
                         extended_hours=extended_hours,
                     )
-                    if buy_sound_path and sell_sound_path:
-                        play_sound(
-                            buy_sound_path if side == OrderSide.BUY else sell_sound_path
-                        )
+                    if voice_agent is None and success_sound_path:
+                        play_sound(success_sound_path)
                     retried = True
                     order = res
                 except Exception as exc2:  # noqa: BLE001

--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -56,6 +56,7 @@ from .views.trades_screen import TradesScreen
 BUY_SOUND_PATH = "res/buy.mp3"
 SELL_SOUND_PATH = "res/sell.mp3"
 INTRO_SOUND_PATH = "res/intro.mp3"
+ORDER_SUCCESS_SOUND_PATH = "res/order_success.mp3"
 
 REFRESH_INTERVAL = 60  # seconds
 SCANNER_INTERVAL = REFRESH_INTERVAL
@@ -350,8 +351,7 @@ class SpectrApp(App):
                     self.trade_amount,
                     self.auto_trading_enabled,
                     voice_agent=self.voice_agent,
-                    buy_sound_path=BUY_SOUND_PATH,
-                    sell_sound_path=SELL_SOUND_PATH,
+                    success_sound_path=ORDER_SUCCESS_SOUND_PATH,
                 )
                 self.call_from_thread(
                     cache.attach_order_to_last_signal,
@@ -628,8 +628,7 @@ class SpectrApp(App):
                             self.trade_amount,
                             self.auto_trading_enabled,
                             voice_agent=self.voice_agent,
-                            buy_sound_path=BUY_SOUND_PATH,
-                            sell_sound_path=SELL_SOUND_PATH,
+                            success_sound_path=ORDER_SUCCESS_SOUND_PATH,
                         )
                         # Save to cache.
                         cache.attach_order_to_last_signal(
@@ -1049,8 +1048,7 @@ class SpectrApp(App):
                 self.auto_trading_enabled,
                 qty=msg.qty,
                 voice_agent=self.voice_agent,
-                buy_sound_path=BUY_SOUND_PATH,
-                sell_sound_path=SELL_SOUND_PATH,
+                success_sound_path=ORDER_SUCCESS_SOUND_PATH,
             )
             cache.attach_order_to_last_signal(
                 self.strategy_signals,

--- a/tests/test_broker_tools.py
+++ b/tests/test_broker_tools.py
@@ -216,3 +216,46 @@ def test_submit_order_manual_qty(monkeypatch):
 
     assert broker.submitted["quantity"] == 3.5
     assert broker.submitted["extended_hours"] is False
+
+
+def test_submit_order_success_sound_without_voice(monkeypatch):
+    quote = {"ask": 10.0, "bid": 9.0}
+    broker = DummyBroker(qty=5, quote=quote)
+    monkeypatch.setattr(broker_tools, "is_market_open_now", lambda tz=None: True)
+
+    played = []
+    monkeypatch.setattr(broker_tools, "play_sound", lambda path: played.append(path))
+
+    broker_tools.submit_order(
+        broker,
+        "NVDA",
+        OrderSide.BUY,
+        price=10.0,
+        trade_amount=10.0,
+        auto_trading_enabled=True,
+        success_sound_path="res/order_success.mp3",
+    )
+
+    assert played == ["res/order_success.mp3"]
+
+
+def test_submit_order_no_success_sound_with_voice(monkeypatch):
+    quote = {"ask": 10.0, "bid": 9.0}
+    broker = DummyBroker(qty=5, quote=quote)
+    monkeypatch.setattr(broker_tools, "is_market_open_now", lambda tz=None: True)
+
+    played = []
+    monkeypatch.setattr(broker_tools, "play_sound", lambda path: played.append(path))
+
+    broker_tools.submit_order(
+        broker,
+        "NVDA",
+        OrderSide.BUY,
+        price=10.0,
+        trade_amount=10.0,
+        auto_trading_enabled=True,
+        voice_agent=object(),
+        success_sound_path="res/order_success.mp3",
+    )
+
+    assert played == []


### PR DESCRIPTION
## Summary
- add ORDER_SUCCESS_SOUND_PATH constant
- play success sound when voice mode disabled
- test order success sound behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bcec6cb520832ea26fa1823e8f5b1a