### PR TITLE
Display backtest trade details in results dialog

### DIFF
--- a/src/spectr/default.tcss
+++ b/src/spectr/default.tcss
@@ -399,6 +399,10 @@ BacktestResultScreen {
     background: black;
 }
 
+#backtest-trades {
+    height: 10;
+}
+
 
 
 # Strategy Screen ------- */

--- a/src/spectr/spectr.py
+++ b/src/spectr/spectr.py
@@ -1428,6 +1428,7 @@ class SpectrApp(App):
                     end_value=result["final_value"],
                     num_buys=num_buys,
                     num_sells=num_sells,
+                    trades=trades,
                 )
             )
 

--- a/src/spectr/strategies/trading_strategy.py
+++ b/src/spectr/strategies/trading_strategy.py
@@ -157,6 +157,8 @@ class TradingStrategy(bt.Strategy):
                     "type": "sell",
                     "time": self.datas[0].datetime.datetime(0),
                     "price": self.datas[0].close[0],
+                    "quantity": qty,
+                    "reason": signal.get("reason"),
                 }
             )
             self.entry_price = None
@@ -164,15 +166,20 @@ class TradingStrategy(bt.Strategy):
 
         if signal and signal.get("signal") == "buy" and not qty:
             log.debug(f"[BACKTEST]: Buy signal detected: {signal['reason']}")
+            cash = self.broker.getcash()
+            price = self.datas[0].close[0]
+            quantity = cash / price if price else 0
             self.buy()
             self.buy_signals.append(
                 {
                     "type": "buy",
                     "time": self.datas[0].datetime.datetime(0),
-                    "price": self.datas[0].close[0],
+                    "price": price,
+                    "quantity": quantity,
+                    "reason": signal.get("reason"),
                 }
             )
-            self.entry_price = self.datas[0].close[0]
+            self.entry_price = price
 
     def next(self) -> None:
         lookback = self.get_lookback()

--- a/src/spectr/views/backtest_result_screen.py
+++ b/src/spectr/views/backtest_result_screen.py
@@ -1,5 +1,5 @@
 from textual.screen import ModalScreen
-from textual.widgets import Static
+from textual.widgets import Static, DataTable
 from textual.containers import Vertical
 
 from .graph_view import GraphView
@@ -23,6 +23,7 @@ class BacktestResultScreen(ModalScreen):
         end_value: float,
         num_buys: int,
         num_sells: int,
+        trades: list[dict],
     ) -> None:
         super().__init__()
         self._graph = graph
@@ -35,12 +36,25 @@ class BacktestResultScreen(ModalScreen):
         self.end_value = end_value
         self.num_buys = num_buys
         self.num_sells = num_sells
+        self.trades = trades
 
     def compose(self):
         self.report.update(self._make_report())
+        table = DataTable(id="backtest-trades", zebra_stripes=True)
+        table.styles.height = 10
+        table.add_columns("Signal", "Price", "Quantity", "Value", "Reason")
+        for trade in self.trades:
+            table.add_row(
+                trade["type"].upper(),
+                f"${trade['price']:.2f}",
+                f"{trade.get('quantity', 0):.4f}",
+                f"${trade['value']:.2f}" if trade.get("value") is not None else "—",
+                trade.get("reason", ""),
+            )
         yield Vertical(
             self._graph,
             self.report,
+            table,
             id="backtest-result-container",
         )
 

--- a/tests/test_overlay_screens.py
+++ b/tests/test_overlay_screens.py
@@ -136,6 +136,7 @@ class BacktestResultApp(App):
             end_value=0.0,
             num_buys=0,
             num_sells=0,
+            trades=[],
         )
         await self.push_screen(self.scr)
 


### PR DESCRIPTION
## Summary
- Track trade quantity and reason during backtests
- Show trades table in backtest result screen with scrollable 10-row view
- Pass collected trades into results screen

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdfcb57ed4832e978f612c3d2d4aea